### PR TITLE
verify_boilerplate: don't require python3

### DIFF
--- a/hack/verify/verify_boilerplate.py
+++ b/hack/verify/verify_boilerplate.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python3
+#!/usr/bin/env python
 
 # Copyright 2015 The Kubernetes Authors.
 #


### PR DESCRIPTION
It seems like this script isn't using any python3-specific features, and the default golang image doesn't have python3 (which makes running this in CI more annoying).