### PR TITLE
Switch to gcr.io/k8s-staging-boskos

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -13,7 +13,7 @@
 # limitations under the License.
 
 WHAT ?= ./...
-DOCKER_REPO ?= gcr.io/k8s-prow/boskos
+DOCKER_REPO ?= gcr.io/k8s-staging-boskos
 DOCKER_TAG ?= v$(shell date -u '+%Y%m%d')-$(shell git describe --tags --always --dirty)
 OUTPUT_DIR ?= _output
 

--- a/images/cloudbuild.yaml
+++ b/images/cloudbuild.yaml
@@ -27,7 +27,7 @@ steps:
     env:
       - DOCKER_CLI_EXPERIMENTAL=enabled
       - DOCKER_TAG=$_GIT_TAG
-      - DOCKER_REPO=gcr.io/$PROJECT_ID/boskos
+      - DOCKER_REPO=gcr.io/$PROJECT_ID
     args:
       - images
 substitutions:
@@ -38,21 +38,21 @@ substitutions:
   # a branch like 'master' or 'release-0.2', or a tag like 'v0.2'.
   _PULL_BASE_REF: "master"
 images:
-  - "gcr.io/$PROJECT_ID/boskos/aws-janitor:$_GIT_TAG"
-  - "gcr.io/$PROJECT_ID/boskos/aws-janitor:latest"
-  - "gcr.io/$PROJECT_ID/boskos/aws-janitor-boskos:$_GIT_TAG"
-  - "gcr.io/$PROJECT_ID/boskos/aws-janitor-boskos:latest"
-  - "gcr.io/$PROJECT_ID/boskos/boskos:$_GIT_TAG"
-  - "gcr.io/$PROJECT_ID/boskos/boskos:latest"
-  - "gcr.io/$PROJECT_ID/boskos/boskosctl:$_GIT_TAG"
-  - "gcr.io/$PROJECT_ID/boskos/boskosctl:latest"
-  - "gcr.io/$PROJECT_ID/boskos/cleaner:$_GIT_TAG"
-  - "gcr.io/$PROJECT_ID/boskos/cleaner:latest"
-  - "gcr.io/$PROJECT_ID/boskos/fake-mason:$_GIT_TAG"
-  - "gcr.io/$PROJECT_ID/boskos/fake-mason:latest"
-  - "gcr.io/$PROJECT_ID/boskos/janitor:$_GIT_TAG"
-  - "gcr.io/$PROJECT_ID/boskos/janitor:latest"
-  - "gcr.io/$PROJECT_ID/boskos/metrics:$_GIT_TAG"
-  - "gcr.io/$PROJECT_ID/boskos/metrics:latest"
-  - "gcr.io/$PROJECT_ID/boskos/reaper:$_GIT_TAG"
-  - "gcr.io/$PROJECT_ID/boskos/reaper:latest"
+  - "gcr.io/$PROJECT_ID/aws-janitor:$_GIT_TAG"
+  - "gcr.io/$PROJECT_ID/aws-janitor:latest"
+  - "gcr.io/$PROJECT_ID/aws-janitor-boskos:$_GIT_TAG"
+  - "gcr.io/$PROJECT_ID/aws-janitor-boskos:latest"
+  - "gcr.io/$PROJECT_ID/boskos:$_GIT_TAG"
+  - "gcr.io/$PROJECT_ID/boskos:latest"
+  - "gcr.io/$PROJECT_ID/boskosctl:$_GIT_TAG"
+  - "gcr.io/$PROJECT_ID/boskosctl:latest"
+  - "gcr.io/$PROJECT_ID/cleaner:$_GIT_TAG"
+  - "gcr.io/$PROJECT_ID/cleaner:latest"
+  - "gcr.io/$PROJECT_ID/fake-mason:$_GIT_TAG"
+  - "gcr.io/$PROJECT_ID/fake-mason:latest"
+  - "gcr.io/$PROJECT_ID/janitor:$_GIT_TAG"
+  - "gcr.io/$PROJECT_ID/janitor:latest"
+  - "gcr.io/$PROJECT_ID/metrics:$_GIT_TAG"
+  - "gcr.io/$PROJECT_ID/metrics:latest"
+  - "gcr.io/$PROJECT_ID/reaper:$_GIT_TAG"
+  - "gcr.io/$PROJECT_ID/reaper:latest"


### PR DESCRIPTION
Rather than using `gcr.io/k8s-prow`, we should probably use our own staging project.

I've created https://github.com/kubernetes/k8s.io/pull/890 to initiate this process. We shouldn't merge this PR until it's in, probably.

/hold