### PR TITLE
Create an opinionated Boskos deployment using kustomize

### DIFF
--- a/deployments/base/cleaner/deployment.yaml
+++ b/deployments/base/cleaner/deployment.yaml
@@ -1,0 +1,44 @@
+# Copyright 2020 The Kubernetes Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: boskos-cleaner
+  labels:
+    app: boskos-cleaner
+  namespace: boskos
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: boskos-cleaner
+  template:
+    metadata:
+      labels:
+        app: boskos-cleaner
+    spec:
+      serviceAccountName: boskos-cleaner
+      terminationGracePeriodSeconds: 300
+      containers:
+        - name: boskos-cleaner
+          image: gcr.io/k8s-staging-boskos/cleaner:v20200617-f289ba6
+          args:
+            - --boskos-url=http://boskos
+            - --namespace=$(NAMESPACE)
+          env:
+            - name: NAMESPACE
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.namespace

--- a/deployments/base/cleaner/deployment.yaml
+++ b/deployments/base/cleaner/deployment.yaml
@@ -37,6 +37,7 @@ spec:
           args:
             - --boskos-url=http://boskos
             - --namespace=$(NAMESPACE)
+            - --use-v2-implementation
           env:
             - name: NAMESPACE
               valueFrom:

--- a/deployments/base/cleaner/kustomization.yaml
+++ b/deployments/base/cleaner/kustomization.yaml
@@ -1,0 +1,23 @@
+# Copyright 2020 The Kubernetes Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+commonLabels:
+  app: boskos-cleaner
+
+resources:
+  - deployment.yaml
+  - rbac.yaml

--- a/deployments/base/cleaner/rbac.yaml
+++ b/deployments/base/cleaner/rbac.yaml
@@ -18,10 +18,11 @@ metadata:
   name: boskos-cleaner
   namespace: boskos
 ---
-kind: RoleBinding
+# Give the cleaner access to update Boskos resources directly
 apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
 metadata:
-  name: boskos-cleaner
+  name: boskos-cleaner-crd-updater
   namespace: boskos
 subjects:
   - kind: ServiceAccount
@@ -29,5 +30,43 @@ subjects:
     namespace: boskos
 roleRef:
   kind: Role
-  name: boskos-crd-reader
+  name: boskos-crd-updater
+  apiGroup: rbac.authorization.k8s.io
+---
+# Give the cleaner access to its leaderlock
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: boskos-cleaner-leaderlock
+rules:
+  - apiGroups:
+      - ""
+    resources:
+      - configmaps
+    resourceNames:
+      - boskos-cleaner-leaderlock
+    verbs:
+      - get
+      - update
+      - create
+  - apiGroups:
+      - ""
+    resources:
+      - configmaps
+      - events
+    verbs:
+      - create
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: boskos-cleaner-leaderlock
+  namespace: boskos
+subjects:
+  - kind: ServiceAccount
+    name: boskos-cleaner
+    namespace: boskos
+roleRef:
+  kind: Role
+  name: boskos-cleaner-leaderlock
   apiGroup: rbac.authorization.k8s.io

--- a/deployments/base/cleaner/rbac.yaml
+++ b/deployments/base/cleaner/rbac.yaml
@@ -1,0 +1,33 @@
+# Copyright 2020 The Kubernetes Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: boskos-cleaner
+  namespace: boskos
+---
+kind: RoleBinding
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: boskos-cleaner
+  namespace: boskos
+subjects:
+  - kind: ServiceAccount
+    name: boskos-cleaner
+    namespace: boskos
+roleRef:
+  kind: Role
+  name: boskos-crd-reader
+  apiGroup: rbac.authorization.k8s.io

--- a/deployments/base/crd.yaml
+++ b/deployments/base/crd.yaml
@@ -1,0 +1,78 @@
+# Copyright 2020 The Kubernetes Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+apiVersion: apiextensions.k8s.io/v1beta1
+kind: CustomResourceDefinition
+metadata:
+  name: dynamicresourcelifecycles.boskos.k8s.io
+spec:
+  group: boskos.k8s.io
+  names:
+    kind: DRLCObject
+    listKind: DRLCObjectList
+    plural: dynamicresourcelifecycles
+    singular: dynamicresourcelifecycle
+  scope: Namespaced
+  version: v1
+  versions:
+    - name: v1
+      served: true
+      storage: true
+  additionalPrinterColumns:
+    - name: Type
+      type: string
+      description: The dynamic resource type.
+      JSONPath: .spec.config.type
+    - name: Min-Count
+      type: integer
+      description: The minimum count requested.
+      JSONPath: .spec.min-count
+    - name: Max-Count
+      type: integer
+      description: The maximum count requested.
+      JSONPath: .spec.max-count
+---
+apiVersion: apiextensions.k8s.io/v1beta1
+kind: CustomResourceDefinition
+metadata:
+  name: resources.boskos.k8s.io
+spec:
+  group: boskos.k8s.io
+  names:
+    kind: ResourceObject
+    listKind: ResourceObjectList
+    plural: resources
+    singular: resource
+  scope: Namespaced
+  version: v1
+  versions:
+    - name: v1
+      served: true
+      storage: true
+  additionalPrinterColumns:
+    - name: Type
+      type: string
+      description: The resource type.
+      JSONPath: .spec.type
+    - name: State
+      type: string
+      description: The current state of the resource.
+      JSONPath: .status.state
+    - name: Owner
+      type: string
+      description: The current owner of the resource.
+      JSONPath: .status.owner
+    - name: Last-Updated
+      type: date
+      JSONPath: .status.lastUpdate

--- a/deployments/base/deployment.yaml
+++ b/deployments/base/deployment.yaml
@@ -1,0 +1,53 @@
+# Copyright 2020 The Kubernetes Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: boskos
+  namespace: boskos
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: boskos
+  template:
+    metadata:
+      labels:
+        app: boskos
+    spec:
+      serviceAccountName: boskos
+      terminationGracePeriodSeconds: 30
+      containers:
+        - name: boskos
+          image: gcr.io/k8s-staging-boskos/boskos:v20200617-f289ba6
+          args:
+            - --config=/etc/config/boskos-resources.yaml
+            - --namespace=$(NAMESPACE)
+          env:
+            - name: NAMESPACE
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.namespace
+          ports:
+            - containerPort: 8080
+              protocol: TCP
+          volumeMounts:
+            - name: boskos-config
+              mountPath: /etc/config
+              readOnly: true
+      volumes:
+        - name: boskos-config
+          configMap:
+            name: boskos-resources

--- a/deployments/base/janitor/README.md
+++ b/deployments/base/janitor/README.md
@@ -1,0 +1,9 @@
+The Janitor requires a bit of overriding in overlays.
+
+At the very least:
+1. You must override the `JANITOR_RESOURCE_TYPES` environment variable in the Deployment to contain the list of resource types this Janitor should manage.
+2. You must ensure the Service Account has necessary credentials to clean up the resources.
+
+You will likely also want to increase the number of replicas.
+
+If you want to have multiple kinds of Janitors (perhaps servicing different resource types), you can create separate overlays for each Janitor. Consult the example overlay for details.

--- a/deployments/base/janitor/deployment.yaml
+++ b/deployments/base/janitor/deployment.yaml
@@ -1,0 +1,47 @@
+# Copyright 2020 The Kubernetes Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: boskos-janitor
+  labels:
+    app: boskos-janitor
+  namespace: boskos
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: boskos-janitor
+  template:
+    metadata:
+      labels:
+        app: boskos-janitor
+    spec:
+      terminationGracePeriodSeconds: 300
+      serviceAccountName: boskos-janitor
+      containers:
+        - name: boskos-janitor
+          image: gcr.io/k8s-staging-boskos/janitor:v20200617-f289ba6
+          args:
+            - --boskos-url=http://boskos
+            - --resource-type=$(JANITOR_RESOURCE_TYPES)
+            - --janitor-path=$(JANITOR_BINARY)
+            - --
+            - --hours=0
+          env:
+            - name: JANITOR_RESOURCE_TYPES
+              value:
+            - name: JANITOR_BINARY
+              value: /bin/gcp_janitor.py

--- a/deployments/base/janitor/kustomization.yaml
+++ b/deployments/base/janitor/kustomization.yaml
@@ -1,0 +1,23 @@
+# Copyright 2020 The Kubernetes Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+commonLabels:
+  app: boskos-janitor
+
+resources:
+  - deployment.yaml
+  - serviceaccount.yaml

--- a/deployments/base/janitor/serviceaccount.yaml
+++ b/deployments/base/janitor/serviceaccount.yaml
@@ -1,0 +1,19 @@
+# Copyright 2020 The Kubernetes Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: boskos-janitor
+  namespace: boskos

--- a/deployments/base/kustomization.yaml
+++ b/deployments/base/kustomization.yaml
@@ -1,0 +1,25 @@
+# Copyright 2020 The Kubernetes Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+commonLabels:
+  app: boskos
+
+resources:
+  - crd.yaml
+  - deployment.yaml
+  - rbac.yaml
+  - service.yaml

--- a/deployments/base/rbac.yaml
+++ b/deployments/base/rbac.yaml
@@ -1,0 +1,53 @@
+# Copyright 2020 The Kubernetes Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+kind: ServiceAccount
+apiVersion: v1
+metadata:
+  name: boskos
+  namespace: boskos
+---
+kind: Role
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: boskos-crd-admin
+  namespace: boskos
+rules:
+  - apiGroups: ["boskos.k8s.io"]
+    resources: ["*"]
+    verbs: ["*"]
+---
+kind: RoleBinding
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: boskos-crd-admin
+  namespace: boskos
+subjects:
+  - kind: ServiceAccount
+    name: boskos
+    namespace: boskos
+roleRef:
+  kind: Role
+  name: boskos-crd-admin
+  apiGroup: rbac.authorization.k8s.io
+---
+kind: Role
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: boskos-crd-reader
+  namespace: boskos
+rules:
+  - apiGroups: ["boskos.k8s.io"]
+    resources: ["*"]
+    verbs: ["get", "list"]

--- a/deployments/base/rbac.yaml
+++ b/deployments/base/rbac.yaml
@@ -50,4 +50,14 @@ metadata:
 rules:
   - apiGroups: ["boskos.k8s.io"]
     resources: ["*"]
-    verbs: ["get", "list"]
+    verbs: ["get", "list", "watch"]
+---
+kind: Role
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: boskos-crd-updater
+  namespace: boskos
+rules:
+  - apiGroups: ["boskos.k8s.io"]
+    resources: ["*"]
+    verbs: ["get", "list", "watch", "update"]

--- a/deployments/base/reaper/README.md
+++ b/deployments/base/reaper/README.md
@@ -1,0 +1,1 @@
+For the Reaper to be functional, you must override the `REAPER_RESOURCE_TYPES` environment variable in overlays.

--- a/deployments/base/reaper/deployment.yaml
+++ b/deployments/base/reaper/deployment.yaml
@@ -1,0 +1,41 @@
+# Copyright 2020 The Kubernetes Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: boskos-reaper
+  labels:
+    app: boskos-reaper
+  namespace: boskos
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: boskos-reaper
+  template:
+    metadata:
+      labels:
+        app: boskos-reaper
+    spec:
+      terminationGracePeriodSeconds: 30
+      containers:
+        - name: boskos-reaper
+          image: gcr.io/k8s-staging-boskos/reaper:v20200617-f289ba6
+          args:
+            - --boskos-url=http://boskos
+            - --resource-type=$(REAPER_RESOURCE_TYPES)
+          env:
+            - name: REAPER_RESOURCE_TYPES
+              value:

--- a/deployments/base/reaper/kustomization.yaml
+++ b/deployments/base/reaper/kustomization.yaml
@@ -1,0 +1,22 @@
+# Copyright 2020 The Kubernetes Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+commonLabels:
+  app: boskos-reaper
+
+resources:
+  - deployment.yaml

--- a/deployments/base/service.yaml
+++ b/deployments/base/service.yaml
@@ -1,0 +1,44 @@
+# Copyright 2020 The Kubernetes Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Expose a cluster-internal service for the Boskos API
+apiVersion: v1
+kind: Service
+metadata:
+  name: boskos
+  namespace: boskos
+spec:
+  selector:
+    app: boskos
+  ports:
+    - name: default
+      protocol: TCP
+      port: 80
+      targetPort: 8080
+---
+# Expose a cluster-external service for Prometheus-style metrics
+apiVersion: v1
+kind: Service
+metadata:
+  name: boskos-metrics
+  namespace: boskos
+spec:
+  selector:
+    app: boskos
+  ports:
+    - name: metrics
+      port: 9090
+      protocol: TCP
+      targetPort: 9090
+  type: LoadBalancer

--- a/deployments/overlays/example/README.md
+++ b/deployments/overlays/example/README.md
@@ -1,0 +1,27 @@
+This overlay creates a fairly simple Boskos deployment in the namespace `boskos-example`.
+
+It manages the following ficticious resources:
+- `phonetic-project` (cleaned by the phonetic janitor)
+- `numeric-project` (cleaned by the numeric janitor)
+- `manual-token`
+- `automatic-token` (automatically scaled using Dynamic Resource Lifecycles, though no Mason implementation is used here)
+
+Beyond the core Boskos server, the following components are installed:
+- The `cleaner`, to clean up `automatic-token`s
+- The `reaper`, to clean up orphaned leases
+- Two deployments of the `janitor`, one to clean up `numeric` projects, the other to clean up `phonetic` projects. Note that we increased the number of replicas for the latter.
+  - In this toy example we overrode the real janitor binary to always pass, since these are not real projects and we do not have a real service account. A real implementation would need to ensure the janitor service account has the necessary credentials, for example by using [Workload Identity on GKE](https://cloud.google.com/kubernetes-engine/docs/how-to/workload-identity).
+
+To try out this example, you will need to [install Kustomize](https://kubernetes-sigs.github.io/kustomize/installation/). (The version of Kustomize included in Kubectl is too old at time of writing.)
+Additionally, to play with this example locally, you can first create a [kind cluster](https://kind.sigs.k8s.io/).
+
+Build the manifests:
+```console
+# from root of this repository; you can also run 'kustomize build .' from within this directory
+$ kustomize build deployments/overlays/example/
+```
+
+Apply to a cluster:
+```console
+$ kustomize build deployments/overlays/example | kubectl apply -f-
+```

--- a/deployments/overlays/example/boskos-resources.yaml
+++ b/deployments/overlays/example/boskos-resources.yaml
@@ -1,0 +1,46 @@
+# Copyright 2020 The Kubernetes Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+resources:
+  - names:
+      - project-alfa
+      - project-bravo
+      - project-charlie
+      - project-delta
+    state: dirty
+    type: phonetic-project
+
+  - names:
+      - project-one
+      - project-two
+      - project-three
+    state: dirty
+    type: numeric-project
+
+  - names:
+      - token-1
+      - token-2
+      - token-3
+      - token-4
+      - token-5
+      - token-6
+      - token-7
+    state: free
+    type: manual-token
+
+  - type: automatic-token
+    state: free
+    min-count: 5
+    max-count: 5
+    lifespan: 5m

--- a/deployments/overlays/example/kustomization.yaml
+++ b/deployments/overlays/example/kustomization.yaml
@@ -1,0 +1,50 @@
+# Copyright 2020 The Kubernetes Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+namespace: boskos-example
+
+bases:
+  - ../../base
+  - ../../base/cleaner
+  - ../../base/reaper
+  - numeric-janitor
+  - phonetic-janitor
+
+resources:
+  - namespace.yaml
+
+configMapGenerator:
+  - name: boskos-resources
+    files:
+      - boskos-resources.yaml
+
+generatorOptions:
+  disableNameSuffixHash: true
+
+patchesJson6902:
+  - target:
+      group: apps
+      version: v1
+      kind: Deployment
+      name: boskos-reaper
+      namespace: boskos
+    patch: |-
+      - op: replace
+        path: /spec/template/spec/containers/0/env
+        value:
+          - name: REAPER_RESOURCE_TYPES
+            value: phonetic-project,numeric-project,manual-token,automatic-token

--- a/deployments/overlays/example/namespace.yaml
+++ b/deployments/overlays/example/namespace.yaml
@@ -1,0 +1,21 @@
+# Copyright 2020 The Kubernetes Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+kind: List
+apiVersion: v1
+items:
+  - kind: Namespace
+    apiVersion: v1
+    metadata:
+      name: boskos-example

--- a/deployments/overlays/example/numeric-janitor/kustomization.yaml
+++ b/deployments/overlays/example/numeric-janitor/kustomization.yaml
@@ -1,0 +1,39 @@
+# Copyright 2020 The Kubernetes Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+nameSuffix: -numeric
+commonLabels:
+  app: boskos-janitor-numeric
+
+bases:
+  - ../../../base/janitor
+
+patchesJson6902:
+  - target:
+      group: apps
+      version: v1
+      kind: Deployment
+      name: boskos-janitor
+      namespace: boskos
+    patch: |-
+      - op: replace
+        path: /spec/template/spec/containers/0/env
+        value:
+          - name: JANITOR_RESOURCE_TYPES
+            value: numeric-project
+          - name: JANITOR_BINARY
+            value: /bin/echo

--- a/deployments/overlays/example/phonetic-janitor/kustomization.yaml
+++ b/deployments/overlays/example/phonetic-janitor/kustomization.yaml
@@ -1,0 +1,43 @@
+# Copyright 2020 The Kubernetes Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+nameSuffix: -phonetic
+commonLabels:
+  app: boskos-janitor-phonetic
+
+bases:
+  - ../../../base/janitor
+
+replicas:
+  - name: boskos-janitor
+    count: 2
+
+patchesJson6902:
+  - target:
+      group: apps
+      version: v1
+      kind: Deployment
+      name: boskos-janitor
+      namespace: boskos
+    patch: |-
+      - op: replace
+        path: /spec/template/spec/containers/0/env
+        value:
+          - name: JANITOR_RESOURCE_TYPES
+            value: phonetic-project
+          - name: JANITOR_BINARY
+            value: /bin/echo


### PR DESCRIPTION
I know we haven't really discussed exactly how we want deployments to work long-term, and I'm not sure how this integrates with bazel-based deployment systems (such as kubernetes/test-infra), but I think that using kustomize generally makes things pretty clear to understand. I guess you can always run `kustomize` and save the output into static YAML files.

I took the existing manifests from kubernetes/test-infra, plus a few others, and massaged them a bit to simplify them.
I haven't yet added the AWS janitor into the mix, though that should be a fairly straightforward followup.
I also didn't enable v2 of the cleaner, since that isn't widely deployed, and it'll probably be helpful to see the diff, anyway.

I've tested this on a kind cluster with `kustomize build deployments/overlays/example  | kubectl apply -f-`, so that's pretty neat. (The kustomize library linked into `kubectl` seems to barf on the inline patches for some reason.)

/assign @alvaroaleman 
cc @chemikadze