### PR TITLE
gcp-janitor: update list of GCP zones

### DIFF
--- a/cmd/janitor/gcp_janitor.py
+++ b/cmd/janitor/gcp_janitor.py
@@ -72,6 +72,82 @@ DEMOLISH_ORDER = [
     Resource('', 'logging', 'sinks', None, None, None, False, False),
 ]
 
+# gcloud compute zones list --format="value(name)" | sort | awk '{print "    \x27"$1"\x27," }'
+ZONES = [
+    'asia-east1-a',
+    'asia-east1-b',
+    'asia-east1-c',
+    'asia-east2-a',
+    'asia-east2-b',
+    'asia-east2-c',
+    'asia-northeast1-a',
+    'asia-northeast1-b',
+    'asia-northeast1-c',
+    'asia-northeast2-a',
+    'asia-northeast2-b',
+    'asia-northeast2-c',
+    'asia-northeast3-a',
+    'asia-northeast3-b',
+    'asia-northeast3-c',
+    'asia-south1-a',
+    'asia-south1-b',
+    'asia-south1-c',
+    'asia-southeast1-a',
+    'asia-southeast1-b',
+    'asia-southeast1-c',
+    'asia-southeast2-a',
+    'asia-southeast2-b',
+    'asia-southeast2-c',
+    'australia-southeast1-a',
+    'australia-southeast1-b',
+    'australia-southeast1-c',
+    'europe-north1-a',
+    'europe-north1-b',
+    'europe-north1-c',
+    'europe-west1-b',
+    'europe-west1-c',
+    'europe-west1-d',
+    'europe-west2-a',
+    'europe-west2-b',
+    'europe-west2-c',
+    'europe-west3-a',
+    'europe-west3-b',
+    'europe-west3-c',
+    'europe-west4-a',
+    'europe-west4-b',
+    'europe-west4-c',
+    'europe-west6-a',
+    'europe-west6-b',
+    'europe-west6-c',
+    'northamerica-northeast1-a',
+    'northamerica-northeast1-b',
+    'northamerica-northeast1-c',
+    'southamerica-east1-a',
+    'southamerica-east1-b',
+    'southamerica-east1-c',
+    'us-central1-a',
+    'us-central1-b',
+    'us-central1-c',
+    'us-central1-f',
+    'us-east1-b',
+    'us-east1-c',
+    'us-east1-d',
+    'us-east4-a',
+    'us-east4-b',
+    'us-east4-c',
+    'us-west1-a',
+    'us-west1-b',
+    'us-west1-c',
+    'us-west2-a',
+    'us-west2-b',
+    'us-west2-c',
+    'us-west3-a',
+    'us-west3-b',
+    'us-west3-c',
+    'us-west4-a',
+    'us-west4-b',
+    'us-west4-c',
+]
 
 def log(message):
     """ print a message if --verbose is set. """
@@ -166,17 +242,7 @@ def collect(project, age, resource, filt, clear_all):
         '--filter=%s' % filt,
         '--project=%s' % project])
     if resource.condition == 'zone' and resource.name != 'sole-tenancy' and resource.name != 'network-endpoint-groups':
-        cmd.append('--zones=asia-east1-a,asia-east1-b,asia-east1-c,asia-east2-a,asia-east2-b,asia-east2-c,' +
-            'asia-northeast1-a,asia-northeast1-b,asia-northeast1-c,asia-northeast2-a,asia-northeast2-b,asia-northeast2-c,' +
-            'asia-northeast3-a,asia-northeast3-b,asia-northeast3-c,asia-south1-a,asia-south1-b,asia-south1-c,' +
-            'asia-southeast1-a,asia-southeast1-b,asia-southeast1-c,australia-southeast1-a,australia-southeast1-b,' +
-            'australia-southeast1-c,europe-north1-a,europe-north1-b,europe-north1-c,europe-west1-b,europe-west1-c,' +
-            'europe-west1-d,europe-west2-a,europe-west2-b,europe-west2-c,europe-west3-a,europe-west3-b,europe-west3-c,' +
-            'europe-west4-a,europe-west4-b,europe-west4-c,europe-west6-a,europe-west6-b,europe-west6-c,' +
-            'northamerica-northeast1-a,northamerica-northeast1-b,northamerica-northeast1-c,southamerica-east1-a,' +
-            'southamerica-east1-b,southamerica-east1-c,us-central1-a,us-central1-b,us-central1-c,us-central1-f,' +
-            'us-east1-b,us-east1-c,us-east1-d,us-east4-a,us-east4-b,us-east4-c,us-west1-a,us-west1-b,us-west1-c,' +
-            'us-west2-a,us-west2-b,us-west2-c,us-west3-a,us-west3-b,us-west3-c')
+        cmd.append('--zones=%s' % ','.join(ZONES))
     log('%r' % cmd)
 
     # TODO(krzyzacy): work around for alpha API list calls


### PR DESCRIPTION
This was last updated a few months ago, and there are more zones now.

I think this is probably safer than relying on `gcloud` to do the right thing itself, given outages we've had in the past. Long-term we still plan to rewrite this janitor in Go.