### PR TITLE
GCP janitor: support GKE hub memberships safely

### DIFF
--- a/cmd/janitor/gcp_janitor.py
+++ b/cmd/janitor/gcp_janitor.py
@@ -28,52 +28,58 @@ import threading
 # A resource that need to be cleared.
 Resource = collections.namedtuple(
     'Resource', 'api_version group name subgroup condition managed tolerate bulk_delete')
-DEMOLISH_ORDER = [
+RESOURCES_BY_API = {
     # [WARNING FROM KRZYZACY] : TOUCH THIS WITH CARE!
-    # ORDER REALLY MATTERS HERE!
+    # ORDER (INSIDE EACH API BLOCK) REALLY MATTERS HERE!
 
     # compute resources
-    Resource('', 'compute', 'instances', None, 'zone', None, False, True),
-    Resource('', 'compute', 'addresses', None, 'global', None, False, True),
-    Resource('', 'compute', 'addresses', None, 'region', None, False, True),
-    Resource('', 'compute', 'disks', None, 'zone', None, False, True),
-    Resource('', 'compute', 'disks', None, 'region', None, False, True),
-    Resource('', 'compute', 'firewall-rules', None, None, None, False, True),
-    Resource('', 'compute', 'forwarding-rules', None, 'global', None, False, True),
-    Resource('', 'compute', 'forwarding-rules', None, 'region', None, False, True),
-    Resource('', 'compute', 'target-http-proxies', None, 'global', None, False, True),
-    Resource('', 'compute', 'target-http-proxies', None, 'region', None, False, True),
-    Resource('', 'compute', 'target-https-proxies', None, 'global', None, False, True),
-    Resource('', 'compute', 'target-https-proxies', None, 'region', None, False, True),
-    Resource('', 'compute', 'target-tcp-proxies', None, None, None, False, True),
-    Resource('', 'compute', 'ssl-certificates', None, 'global', None, False, True),
-    Resource('', 'compute', 'ssl-certificates', None, 'region', None, False, True),
-    Resource('', 'compute', 'url-maps', None, 'global', None, False, True),
-    Resource('', 'compute', 'url-maps', None, 'region', None, False, True),
-    Resource('', 'compute', 'backend-services', None, 'global', None, False, True),
-    Resource('', 'compute', 'backend-services', None, 'region', None, False, True),
-    Resource('', 'compute', 'target-pools', None, 'region', None, False, True),
-    Resource('', 'compute', 'health-checks', None, 'global', None, False, True),
-    Resource('', 'compute', 'health-checks', None, 'region', None, False, True),
-    Resource('', 'compute', 'http-health-checks', None, None, None, False, True),
-    Resource('', 'compute', 'instance-groups', None, 'region', 'Yes', False, True),
-    Resource('', 'compute', 'instance-groups', None, 'zone', 'Yes', False, True),
-    Resource('', 'compute', 'instance-groups', None, 'zone', 'No', False, True),
-    Resource('', 'compute', 'instance-templates', None, None, None, False, True),
-    Resource('', 'compute', 'sole-tenancy', 'node-groups', 'zone', None, False, True),
-    Resource('', 'compute', 'sole-tenancy', 'node-templates', 'region', None, False, True),
-    Resource('', 'compute', 'network-endpoint-groups', None, 'zone', None, False, False),
-    Resource('', 'compute', 'routes', None, None, None, False, True),
-    Resource('', 'compute', 'routers', None, 'region', None, False, True),
-    Resource('', 'compute', 'networks', 'subnets', 'region', None, True, True),
-    Resource('', 'compute', 'networks', None, None, None, False, True),
+    'compute.googleapis.com': [
+        Resource('', 'compute', 'instances', None, 'zone', None, False, True),
+        Resource('', 'compute', 'addresses', None, 'global', None, False, True),
+        Resource('', 'compute', 'addresses', None, 'region', None, False, True),
+        Resource('', 'compute', 'disks', None, 'zone', None, False, True),
+        Resource('', 'compute', 'disks', None, 'region', None, False, True),
+        Resource('', 'compute', 'firewall-rules', None, None, None, False, True),
+        Resource('', 'compute', 'forwarding-rules', None, 'global', None, False, True),
+        Resource('', 'compute', 'forwarding-rules', None, 'region', None, False, True),
+        Resource('', 'compute', 'target-http-proxies', None, 'global', None, False, True),
+        Resource('', 'compute', 'target-http-proxies', None, 'region', None, False, True),
+        Resource('', 'compute', 'target-https-proxies', None, 'global', None, False, True),
+        Resource('', 'compute', 'target-https-proxies', None, 'region', None, False, True),
+        Resource('', 'compute', 'target-tcp-proxies', None, None, None, False, True),
+        Resource('', 'compute', 'ssl-certificates', None, 'global', None, False, True),
+        Resource('', 'compute', 'ssl-certificates', None, 'region', None, False, True),
+        Resource('', 'compute', 'url-maps', None, 'global', None, False, True),
+        Resource('', 'compute', 'url-maps', None, 'region', None, False, True),
+        Resource('', 'compute', 'backend-services', None, 'global', None, False, True),
+        Resource('', 'compute', 'backend-services', None, 'region', None, False, True),
+        Resource('', 'compute', 'target-pools', None, 'region', None, False, True),
+        Resource('', 'compute', 'health-checks', None, 'global', None, False, True),
+        Resource('', 'compute', 'health-checks', None, 'region', None, False, True),
+        Resource('', 'compute', 'http-health-checks', None, None, None, False, True),
+        Resource('', 'compute', 'instance-groups', None, 'region', 'Yes', False, True),
+        Resource('', 'compute', 'instance-groups', None, 'zone', 'Yes', False, True),
+        Resource('', 'compute', 'instance-groups', None, 'zone', 'No', False, True),
+        Resource('', 'compute', 'instance-templates', None, None, None, False, True),
+        Resource('', 'compute', 'sole-tenancy', 'node-groups', 'zone', None, False, True),
+        Resource('', 'compute', 'sole-tenancy', 'node-templates', 'region', None, False, True),
+        Resource('', 'compute', 'network-endpoint-groups', None, 'zone', None, False, False),
+        Resource('', 'compute', 'routes', None, None, None, False, True),
+        Resource('', 'compute', 'routers', None, 'region', None, False, True),
+        Resource('', 'compute', 'networks', 'subnets', 'region', None, True, True),
+        Resource('', 'compute', 'networks', None, None, None, False, True),
+    ],
 
     # logging resources
-    Resource('', 'logging', 'sinks', None, None, None, False, False),
+    'logging.googleapis.com': [
+        Resource('', 'logging', 'sinks', None, None, None, False, False),
+    ],
 
     # GKE hub memberships
-    Resource('', 'container', 'hub', 'memberships', None, None, False, False)
-]
+    'gkehub.googleapis.com': [
+        Resource('', 'container', 'hub', 'memberships', None, None, False, False),
+    ],
+}
 
 # gcloud compute zones list --format="value(name)" | sort | awk '{print "    \x27"$1"\x27," }'
 ZONES = [
@@ -449,6 +455,27 @@ def activate_service_account(service_account):
     return 0
 
 
+# Returns whether the specified GCP API is enabled on the provided project.
+def api_enabled(project, api):
+    log("checking whether API %s is enabled" % api)
+    cmd = [
+        'gcloud', 'services', '-q', 'list',
+        '--project=%s' % project,
+        '--filter=config.name="%s"' % api,
+        '--format=value(state)'
+    ]
+    log('running %s' % cmd)
+    state = subprocess.check_output(cmd).decode().strip()
+    if state == '':
+        log('API %s is not enabled' % api)
+        return False
+    if state == 'ENABLED':
+        log('API %s is enabled' % api)
+        return True
+    print('Unexpected state for API %s: %s' % (api, state))
+    return False
+
+
 def main(project, days, hours, filt, rate_limit, service_account):
     """ Clean up resources from a gcp project based on it's creation time
 
@@ -480,17 +507,20 @@ def main(project, days, hours, filt, rate_limit, service_account):
         err |= 1  # keep clean the other resource
         print('Fail to clean up cluster from project %r' % project, file=sys.stderr)
 
-    for res in DEMOLISH_ORDER:
-        log('Try to search for %r with condition %r, managed %r' % (
-            res.name, res.condition, res.managed))
-        try:
-            col = collect(project, age, res, filt, clear_all)
-            if col:
-                err |= clear_resources(project, col, res, rate_limit)
-        except (subprocess.CalledProcessError, ValueError) as exc:
-            err |= 1  # keep clean the other resource
-            print('Fail to list resource %r from project %r: %r' % (res.name, project, exc),
-                  file=sys.stderr)
+    for api, resources in RESOURCES_BY_API.items():
+        if not api_enabled(project, api):
+            continue
+        for res in resources:
+            log('Try to search for %r with condition %r, managed %r' % (
+                res.name, res.condition, res.managed))
+            try:
+                col = collect(project, age, res, filt, clear_all)
+                if col:
+                    err |= clear_resources(project, col, res, rate_limit)
+            except (subprocess.CalledProcessError, ValueError) as exc:
+                err |= 1  # keep clean the other resource
+                print('Fail to list resource %r from project %r: %r' % (res.name, project, exc),
+                    file=sys.stderr)
 
     print('[=== Finish Janitor on project %r with status %r ===]' % (project, err))
     sys.exit(err)

--- a/cmd/janitor/gcp_janitor.py
+++ b/cmd/janitor/gcp_janitor.py
@@ -520,7 +520,7 @@ def main(project, days, hours, filt, rate_limit, service_account):
             except (subprocess.CalledProcessError, ValueError) as exc:
                 err |= 1  # keep clean the other resource
                 print('Fail to list resource %r from project %r: %r' % (res.name, project, exc),
-                    file=sys.stderr)
+                      file=sys.stderr)
 
     print('[=== Finish Janitor on project %r with status %r ===]' % (project, err))
     sys.exit(err)

--- a/images/janitor/Dockerfile
+++ b/images/janitor/Dockerfile
@@ -35,7 +35,7 @@ RUN make build
 ARG cmd
 RUN make "${cmd}"
 
-FROM gcr.io/google.com/cloudsdktool/cloud-sdk:277.0.0-slim
+FROM gcr.io/google.com/cloudsdktool/cloud-sdk:303.0.0-slim
 COPY ./cmd/janitor/gcp_janitor.py /bin
 
 ARG cmd


### PR DESCRIPTION
I hadn't tested #34 enough; after it was merged, I realized the version of `gcloud` in the janitor image was too old.
I updated that, which then revealed two new problems:
- python2 was no longer part of the image
- the GKE hub API isn't enabled on projects by default

I updated the script to be python3-compatible (I believe), and I added guards to ensure the necessary GCP APIs are enabled on the project. (If they aren't, we just skip those resources.)