### PR TITLE
Update to go 1.15.2 and alpine 3.12

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -27,7 +27,7 @@ GOLANGCI_LINT := $(TOOLS_BIN_DIR)/golangci-lint
 
 CMDS = $(notdir $(shell find ./cmd/ -maxdepth 1 -type d | sort))
 
-export GO_VERSION=1.15.1
+export GO_VERSION=1.15.2
 export GO111MODULE=on
 export DOCKER_REPO
 export DOCKER_TAG

--- a/images/boskosctl/Dockerfile
+++ b/images/boskosctl/Dockerfile
@@ -15,7 +15,7 @@
 # Installs a few extra tools folks might want to use when running boskosctl.
 
 ARG go_version
-ARG alpine_version=3.11
+ARG alpine_version=3.12
 
 FROM golang:${go_version}-alpine${alpine_version} as build
 WORKDIR /go/src/app


### PR DESCRIPTION
The boskosctl image has been failing to build, since apparently the version of alpine we were using was no longer supported:
```
Step 3/18 : FROM golang:${go_version}-alpine${alpine_version} as build
manifest for golang:1.15.1-alpine3.11 not found: manifest unknown: manifest unknown
make: *** [Makefile:65: boskosctl-image] Error 1
```