### PR TITLE
GCP Janitor also cleans up pubsub resources

### DIFF
--- a/cmd/janitor/gcp_janitor.py
+++ b/cmd/janitor/gcp_janitor.py
@@ -76,6 +76,14 @@ RESOURCES_BY_API = {
         Resource('', 'logging', 'sinks', None, None, None, False, False, ['_Default', '_Required']),
     ],
 
+    # pubsub resources
+    'pubsub.googleapis.com': [
+        Resource('', 'pubsub', 'subscriptions', None, None, None, False, True, None),
+        Resource('', 'pubsub', 'topics', None, None, None, False, True,
+                 ['container-analysis-notes-v1', 'container-analysis-notes-v1beta1',
+                  'container-analysis-occurrences-v1', 'container-analysis-occurrences-v1beta1'])
+    ],
+
     # GKE hub memberships
     'gkehub.googleapis.com': [
         Resource('', 'container', 'hub', 'memberships', None, None, False, False, None),


### PR DESCRIPTION
Not sure if we can add arbitrary GCP resources for Janitor to clean up, but the use case is in some of the Knative integration test flows, they create `pubsub` resources which are possible to be leaked. Currently we are running the `gcloud pubsub delete` commands before the workflow actually starts, but the best way seems to be asking Janitor to clean them up.

I'm setting `tolerate=True` here, then it won't report as failure if the cleanup command fails(?)