### PR TITLE
aws-janitor: add --dry-run functionality

### DIFF
--- a/aws-janitor/resources/addresses.go
+++ b/aws-janitor/resources/addresses.go
@@ -43,6 +43,9 @@ func (Addresses) MarkAndSweep(opts Options, set *Set) error {
 		a := &address{Account: opts.Account, Region: opts.Region, ID: *addr.AllocationId}
 		if set.Mark(a) {
 			logger.Warningf("%s: deleting %T: %s", a.ARN(), addr, a.ID)
+			if opts.DryRun {
+				continue
+			}
 
 			if addr.AssociationId != nil {
 				logger.Warningf("%s: disassociating %T from active instance", a.ARN(), addr)

--- a/aws-janitor/resources/asg.go
+++ b/aws-janitor/resources/asg.go
@@ -40,7 +40,9 @@ func (AutoScalingGroups) MarkAndSweep(opts Options, set *Set) error {
 			a := &autoScalingGroup{ID: *asg.AutoScalingGroupARN, Name: *asg.AutoScalingGroupName}
 			if set.Mark(a) {
 				logger.Warningf("%s: deleting %T: %s", a.ARN(), asg, a.Name)
-				toDelete = append(toDelete, a)
+				if !opts.DryRun {
+					toDelete = append(toDelete, a)
+				}
 			}
 		}
 		return true

--- a/aws-janitor/resources/clean.go
+++ b/aws-janitor/resources/clean.go
@@ -31,7 +31,7 @@ import (
 
 // CleanAll cleans all of the resources for all of the regions visible to
 // the provided AWS session.
-func CleanAll(sess *session.Session, region string) error {
+func CleanAll(sess *session.Session, region string, dryRun bool) error {
 	acct, err := account.GetAccount(sess, regions.Default)
 	if err != nil {
 		return errors.Wrap(err, "Failed to retrieve account")
@@ -54,6 +54,7 @@ func CleanAll(sess *session.Session, region string) error {
 	opts := Options{
 		Session: sess,
 		Account: acct,
+		DryRun:  dryRun,
 	}
 	for _, r := range regionList {
 		opts.Region = r

--- a/aws-janitor/resources/clean.go
+++ b/aws-janitor/resources/clean.go
@@ -57,13 +57,15 @@ func CleanAll(sess *session.Session, region string) error {
 	}
 	for _, r := range regionList {
 		opts.Region = r
+		logger := logrus.WithField("options", opts)
 		for _, typ := range RegionalTypeList {
+			logger.Debugf("Cleaning resource type %T", typ)
 			set, err := typ.ListAll(opts)
 			if err != nil {
 				// ignore errors for resources we do not have permissions to list
 				if reqerr, ok := errors.Cause(err).(awserr.RequestFailure); ok {
 					if reqerr.StatusCode() == http.StatusForbidden {
-						logrus.Debugf("Skipping resources of type %T, account does not have permission to list", typ)
+						logger.Debugf("Skipping resources of type %T, account does not have permission to list", typ)
 						continue
 					}
 				}
@@ -71,7 +73,7 @@ func CleanAll(sess *session.Session, region string) error {
 				continue
 			}
 			if err := typ.MarkAndSweep(opts, set); err != nil {
-				errs = append(errs, errors.Wrapf(err, "Failed to list resources of type %T", typ))
+				errs = append(errs, errors.Wrapf(err, "Failed to mark and sweep resources of type %T", typ))
 			}
 		}
 	}
@@ -84,7 +86,7 @@ func CleanAll(sess *session.Session, region string) error {
 			continue
 		}
 		if err := typ.MarkAndSweep(opts, set); err != nil {
-			errs = append(errs, errors.Wrapf(err, "Failed to list resources of type %T", typ))
+			errs = append(errs, errors.Wrapf(err, "Failed to mark and sweep resources of type %T", typ))
 		}
 	}
 

--- a/aws-janitor/resources/cloud_formation_stacks.go
+++ b/aws-janitor/resources/cloud_formation_stacks.go
@@ -20,7 +20,6 @@ import (
 	"time"
 
 	"github.com/aws/aws-sdk-go/aws"
-	"github.com/aws/aws-sdk-go/aws/session"
 	cf "github.com/aws/aws-sdk-go/service/cloudformation"
 	"github.com/pkg/errors"
 	"github.com/sirupsen/logrus"
@@ -29,8 +28,8 @@ import (
 // Cloud Formation Stacks
 type CloudFormationStacks struct{}
 
-func (CloudFormationStacks) MarkAndSweep(sess *session.Session, acct string, region string, set *Set) error {
-	svc := cf.New(sess, &aws.Config{Region: aws.String(region)})
+func (CloudFormationStacks) MarkAndSweep(opts Options, set *Set) error {
+	svc := cf.New(opts.Session, aws.NewConfig().WithRegion(opts.Region))
 
 	var toDelete []*cloudFormationStack // Paged call, defer deletion until we have the whole list.
 
@@ -67,8 +66,8 @@ func (CloudFormationStacks) MarkAndSweep(sess *session.Session, acct string, reg
 	return nil
 }
 
-func (CloudFormationStacks) ListAll(sess *session.Session, acct, region string) (*Set, error) {
-	svc := cf.New(sess, aws.NewConfig().WithRegion(region))
+func (CloudFormationStacks) ListAll(opts Options) (*Set, error) {
+	svc := cf.New(opts.Session, aws.NewConfig().WithRegion(opts.Region))
 	set := NewSet(0)
 	inp := &cf.ListStacksInput{}
 
@@ -81,7 +80,7 @@ func (CloudFormationStacks) ListAll(sess *session.Session, acct, region string) 
 		return true
 	})
 
-	return set, errors.Wrapf(err, "couldn't describe cloud formation stacks for %q in %q", acct, region)
+	return set, errors.Wrapf(err, "couldn't describe cloud formation stacks for %q in %q", opts.Account, opts.Region)
 }
 
 type cloudFormationStack struct {

--- a/aws-janitor/resources/cloud_formation_stacks.go
+++ b/aws-janitor/resources/cloud_formation_stacks.go
@@ -29,6 +29,7 @@ import (
 type CloudFormationStacks struct{}
 
 func (CloudFormationStacks) MarkAndSweep(opts Options, set *Set) error {
+	logger := logrus.WithField("options", opts)
 	svc := cf.New(opts.Session, aws.NewConfig().WithRegion(opts.Region))
 
 	var toDelete []*cloudFormationStack // Paged call, defer deletion until we have the whole list.
@@ -47,7 +48,7 @@ func (CloudFormationStacks) MarkAndSweep(opts Options, set *Set) error {
 				name: aws.StringValue(stack.StackName),
 			}
 			if set.Mark(o) {
-				logrus.Warningf("%s: deleting %T: %s", o.ARN(), o, o.name)
+				logger.Warningf("%s: deleting %T: %s", o.ARN(), o, o.name)
 				toDelete = append(toDelete, o)
 			}
 		}
@@ -60,7 +61,7 @@ func (CloudFormationStacks) MarkAndSweep(opts Options, set *Set) error {
 
 	for _, o := range toDelete {
 		if err := o.delete(svc); err != nil {
-			logrus.Warningf("%s: delete failed: %v", o.ARN(), err)
+			logger.Warningf("%s: delete failed: %v", o.ARN(), err)
 		}
 	}
 	return nil

--- a/aws-janitor/resources/cloud_formation_stacks.go
+++ b/aws-janitor/resources/cloud_formation_stacks.go
@@ -49,7 +49,9 @@ func (CloudFormationStacks) MarkAndSweep(opts Options, set *Set) error {
 			}
 			if set.Mark(o) {
 				logger.Warningf("%s: deleting %T: %s", o.ARN(), o, o.name)
-				toDelete = append(toDelete, o)
+				if !opts.DryRun {
+					toDelete = append(toDelete, o)
+				}
 			}
 		}
 		return true

--- a/aws-janitor/resources/dhcp_options.go
+++ b/aws-janitor/resources/dhcp_options.go
@@ -31,6 +31,7 @@ import (
 type DHCPOptions struct{}
 
 func (DHCPOptions) MarkAndSweep(opts Options, set *Set) error {
+	logger := logrus.WithField("options", opts)
 	svc := ec2.New(opts.Session, aws.NewConfig().WithRegion(opts.Region))
 
 	// This is a little gross, but I can't find an easier way to
@@ -73,16 +74,16 @@ func (DHCPOptions) MarkAndSweep(opts Options, set *Set) error {
 
 		dh := &dhcpOption{Account: opts.Account, Region: opts.Region, ID: *dhcp.DhcpOptionsId}
 		if set.Mark(dh) {
-			logrus.Warningf("%s: deleting %T: %s", dh.ARN(), dhcp, dh.ID)
+			logger.Warningf("%s: deleting %T: %s", dh.ARN(), dhcp, dh.ID)
 
 			if _, err := svc.DeleteDhcpOptions(&ec2.DeleteDhcpOptionsInput{DhcpOptionsId: dhcp.DhcpOptionsId}); err != nil {
-				logrus.Warningf("%s: delete failed: %v", dh.ARN(), err)
+				logger.Warningf("%s: delete failed: %v", dh.ARN(), err)
 			}
 		}
 	}
 
 	if len(defaults) > 1 {
-		logrus.Errorf("Found more than one default-looking DHCP option set: %s", strings.Join(defaults, ", "))
+		logger.Errorf("Found more than one default-looking DHCP option set: %s", strings.Join(defaults, ", "))
 	}
 
 	return nil

--- a/aws-janitor/resources/dhcp_options.go
+++ b/aws-janitor/resources/dhcp_options.go
@@ -75,6 +75,9 @@ func (DHCPOptions) MarkAndSweep(opts Options, set *Set) error {
 		dh := &dhcpOption{Account: opts.Account, Region: opts.Region, ID: *dhcp.DhcpOptionsId}
 		if set.Mark(dh) {
 			logger.Warningf("%s: deleting %T: %s", dh.ARN(), dhcp, dh.ID)
+			if opts.DryRun {
+				continue
+			}
 
 			if _, err := svc.DeleteDhcpOptions(&ec2.DeleteDhcpOptionsInput{DhcpOptionsId: dhcp.DhcpOptionsId}); err != nil {
 				logger.Warningf("%s: delete failed: %v", dh.ARN(), err)

--- a/aws-janitor/resources/dhcp_options.go
+++ b/aws-janitor/resources/dhcp_options.go
@@ -22,7 +22,6 @@ import (
 	"time"
 
 	"github.com/aws/aws-sdk-go/aws"
-	"github.com/aws/aws-sdk-go/aws/session"
 	"github.com/aws/aws-sdk-go/service/ec2"
 	"github.com/pkg/errors"
 	"github.com/sirupsen/logrus"
@@ -31,8 +30,8 @@ import (
 // DHCPOptions: https://docs.aws.amazon.com/sdk-for-go/api/service/ec2/#EC2.DescribeDhcpOptions
 type DHCPOptions struct{}
 
-func (DHCPOptions) MarkAndSweep(sess *session.Session, acct string, region string, set *Set) error {
-	svc := ec2.New(sess, &aws.Config{Region: aws.String(region)})
+func (DHCPOptions) MarkAndSweep(opts Options, set *Set) error {
+	svc := ec2.New(opts.Session, aws.NewConfig().WithRegion(opts.Region))
 
 	// This is a little gross, but I can't find an easier way to
 	// figure out the DhcpOptions associated with the default VPC.
@@ -67,12 +66,12 @@ func (DHCPOptions) MarkAndSweep(sess *session.Session, acct string, region strin
 		}
 
 		// Separately, skip any "default looking" DHCP Option Sets. See comment below.
-		if defaultLookingDHCPOptions(dhcp, region) {
+		if defaultLookingDHCPOptions(dhcp, opts.Region) {
 			defaults = append(defaults, *dhcp.DhcpOptionsId)
 			continue
 		}
 
-		dh := &dhcpOption{Account: acct, Region: region, ID: *dhcp.DhcpOptionsId}
+		dh := &dhcpOption{Account: opts.Account, Region: opts.Region, ID: *dhcp.DhcpOptionsId}
 		if set.Mark(dh) {
 			logrus.Warningf("%s: deleting %T: %s", dh.ARN(), dhcp, dh.ID)
 
@@ -89,22 +88,22 @@ func (DHCPOptions) MarkAndSweep(sess *session.Session, acct string, region strin
 	return nil
 }
 
-func (DHCPOptions) ListAll(sess *session.Session, acct, region string) (*Set, error) {
-	svc := ec2.New(sess, aws.NewConfig().WithRegion(region))
+func (DHCPOptions) ListAll(opts Options) (*Set, error) {
+	svc := ec2.New(opts.Session, aws.NewConfig().WithRegion(opts.Region))
 	set := NewSet(0)
 	inp := &ec2.DescribeDhcpOptionsInput{}
 
 	optsList, err := svc.DescribeDhcpOptions(inp)
 	if err != nil {
-		return nil, errors.Wrapf(err, "couldn't describe DHCP Options for %q in %q", acct, region)
+		return nil, errors.Wrapf(err, "couldn't describe DHCP Options for %q in %q", opts.Account, opts.Region)
 	}
 
 	now := time.Now()
-	for _, opts := range optsList.DhcpOptions {
+	for _, dhcpOpts := range optsList.DhcpOptions {
 		arn := dhcpOption{
-			Account: acct,
-			Region:  region,
-			ID:      *opts.DhcpOptionsId,
+			Account: opts.Account,
+			Region:  opts.Region,
+			ID:      *dhcpOpts.DhcpOptionsId,
 		}.ARN()
 		set.firstSeen[arn] = now
 	}

--- a/aws-janitor/resources/elb.go
+++ b/aws-janitor/resources/elb.go
@@ -40,7 +40,9 @@ func (ClassicLoadBalancers) MarkAndSweep(opts Options, set *Set) error {
 			a := &classicLoadBalancer{region: opts.Region, account: opts.Account, name: *lb.LoadBalancerName, dnsName: *lb.DNSName}
 			if set.Mark(a) {
 				logger.Warningf("%s: deleting %T: %s", a.ARN(), lb, a.name)
-				toDelete = append(toDelete, a)
+				if !opts.DryRun {
+					toDelete = append(toDelete, a)
+				}
 			}
 		}
 		return true

--- a/aws-janitor/resources/elbv2.go
+++ b/aws-janitor/resources/elbv2.go
@@ -20,7 +20,6 @@ import (
 	"time"
 
 	"github.com/aws/aws-sdk-go/aws"
-	"github.com/aws/aws-sdk-go/aws/session"
 	"github.com/aws/aws-sdk-go/service/elbv2"
 	"github.com/pkg/errors"
 	"github.com/sirupsen/logrus"
@@ -30,8 +29,8 @@ import (
 
 type LoadBalancers struct{}
 
-func (LoadBalancers) MarkAndSweep(sess *session.Session, account string, region string, set *Set) error {
-	svc := elbv2.New(sess, aws.NewConfig().WithRegion(region))
+func (LoadBalancers) MarkAndSweep(opts Options, set *Set) error {
+	svc := elbv2.New(opts.Session, aws.NewConfig().WithRegion(opts.Region))
 
 	var toDelete []*loadBalancer // Paged call, defer deletion until we have the whole list.
 
@@ -63,8 +62,8 @@ func (LoadBalancers) MarkAndSweep(sess *session.Session, account string, region 
 	return nil
 }
 
-func (LoadBalancers) ListAll(sess *session.Session, acct, region string) (*Set, error) {
-	c := elbv2.New(sess, aws.NewConfig().WithRegion(region))
+func (LoadBalancers) ListAll(opts Options) (*Set, error) {
+	c := elbv2.New(opts.Session, aws.NewConfig().WithRegion(opts.Region))
 	set := NewSet(0)
 	input := &elbv2.DescribeLoadBalancersInput{}
 
@@ -78,7 +77,7 @@ func (LoadBalancers) ListAll(sess *session.Session, acct, region string) (*Set, 
 		return true
 	})
 
-	return set, errors.Wrapf(err, "couldn't describe load balancers for %q in %q", acct, region)
+	return set, errors.Wrapf(err, "couldn't describe load balancers for %q in %q", opts.Account, opts.Region)
 }
 
 type loadBalancer struct {

--- a/aws-janitor/resources/elbv2.go
+++ b/aws-janitor/resources/elbv2.go
@@ -40,7 +40,9 @@ func (LoadBalancers) MarkAndSweep(opts Options, set *Set) error {
 			a := &loadBalancer{arn: *lb.LoadBalancerArn}
 			if set.Mark(a) {
 				logger.Warningf("%s: deleting %T: %s", a.ARN(), lb, *lb.LoadBalancerName)
-				toDelete = append(toDelete, a)
+				if !opts.DryRun {
+					toDelete = append(toDelete, a)
+				}
 			}
 		}
 		return true

--- a/aws-janitor/resources/iam_instance_profiles.go
+++ b/aws-janitor/resources/iam_instance_profiles.go
@@ -57,7 +57,9 @@ func (IAMInstanceProfiles) MarkAndSweep(opts Options, set *Set) error {
 			o := &iamInstanceProfile{profile: p}
 			if set.Mark(o) {
 				logger.Warningf("%s: deleting %T: %s", o.ARN(), o, o.ARN())
-				toDelete = append(toDelete, o)
+				if !opts.DryRun {
+					toDelete = append(toDelete, o)
+				}
 			}
 		}
 		return true

--- a/aws-janitor/resources/iam_instance_profiles.go
+++ b/aws-janitor/resources/iam_instance_profiles.go
@@ -20,7 +20,6 @@ import (
 	"time"
 
 	"github.com/aws/aws-sdk-go/aws"
-	"github.com/aws/aws-sdk-go/aws/session"
 	"github.com/aws/aws-sdk-go/service/iam"
 	"github.com/pkg/errors"
 	"github.com/sirupsen/logrus"
@@ -29,8 +28,8 @@ import (
 // IAM Instance Profiles
 type IAMInstanceProfiles struct{}
 
-func (IAMInstanceProfiles) MarkAndSweep(sess *session.Session, acct string, region string, set *Set) error {
-	svc := iam.New(sess, &aws.Config{Region: aws.String(region)})
+func (IAMInstanceProfiles) MarkAndSweep(opts Options, set *Set) error {
+	svc := iam.New(opts.Session, aws.NewConfig().WithRegion(opts.Region))
 
 	var toDelete []*iamInstanceProfile // Paged call, defer deletion until we have the whole list.
 
@@ -75,8 +74,8 @@ func (IAMInstanceProfiles) MarkAndSweep(sess *session.Session, acct string, regi
 	return nil
 }
 
-func (IAMInstanceProfiles) ListAll(sess *session.Session, acct, region string) (*Set, error) {
-	svc := iam.New(sess, aws.NewConfig().WithRegion(region))
+func (IAMInstanceProfiles) ListAll(opts Options) (*Set, error) {
+	svc := iam.New(opts.Session, aws.NewConfig().WithRegion(opts.Region))
 	set := NewSet(0)
 	inp := &iam.ListInstanceProfilesInput{}
 
@@ -93,7 +92,7 @@ func (IAMInstanceProfiles) ListAll(sess *session.Session, acct, region string) (
 		return true
 	})
 
-	return set, errors.Wrapf(err, "couldn't describe iam instance profiles for %q in %q", acct, region)
+	return set, errors.Wrapf(err, "couldn't describe iam instance profiles for %q in %q", opts.Account, opts.Region)
 }
 
 type iamInstanceProfile struct {

--- a/aws-janitor/resources/iam_roles.go
+++ b/aws-janitor/resources/iam_roles.go
@@ -65,7 +65,9 @@ func (IAMRoles) MarkAndSweep(opts Options, set *Set) error {
 			l := &iamRole{arn: aws.StringValue(r.Arn), roleID: aws.StringValue(r.RoleId), roleName: aws.StringValue(r.RoleName)}
 			if set.Mark(l) {
 				logger.Warningf("%s: deleting %T: %s", l.ARN(), r, l.roleName)
-				toDelete = append(toDelete, l)
+				if !opts.DryRun {
+					toDelete = append(toDelete, l)
+				}
 			}
 		}
 		return true

--- a/aws-janitor/resources/instance.go
+++ b/aws-janitor/resources/instance.go
@@ -57,7 +57,9 @@ func (Instances) MarkAndSweep(opts Options, set *Set) error {
 
 				if set.Mark(i) {
 					logger.Warningf("%s: deleting %T: %s", i.ARN(), inst, i.InstanceID)
-					toDelete = append(toDelete, inst.InstanceId)
+					if !opts.DryRun {
+						toDelete = append(toDelete, inst.InstanceId)
+					}
 				}
 			}
 		}

--- a/aws-janitor/resources/internet_gateways.go
+++ b/aws-janitor/resources/internet_gateways.go
@@ -65,6 +65,9 @@ func (InternetGateways) MarkAndSweep(opts Options, set *Set) error {
 		if set.Mark(i) {
 			isDefault := false
 			logger.Warningf("%s: deleting %T: %s", i.ARN(), ig, i.ID)
+			if opts.DryRun {
+				continue
+			}
 
 			for _, att := range ig.Attachments {
 				if defaultVPC[aws.StringValue(att.VpcId)] {

--- a/aws-janitor/resources/launch_configs.go
+++ b/aws-janitor/resources/launch_configs.go
@@ -39,7 +39,9 @@ func (LaunchConfigurations) MarkAndSweep(opts Options, set *Set) error {
 			l := &launchConfiguration{ID: *lc.LaunchConfigurationARN, Name: *lc.LaunchConfigurationName}
 			if set.Mark(l) {
 				logger.Warningf("%s: deleting %T: %s", l.ARN(), lc, l.Name)
-				toDelete = append(toDelete, l)
+				if !opts.DryRun {
+					toDelete = append(toDelete, l)
+				}
 			}
 		}
 		return true

--- a/aws-janitor/resources/launch_templates.go
+++ b/aws-janitor/resources/launch_templates.go
@@ -30,6 +30,7 @@ import (
 type LaunchTemplates struct{}
 
 func (LaunchTemplates) MarkAndSweep(opts Options, set *Set) error {
+	logger := logrus.WithField("options", opts)
 	svc := ec2.New(opts.Session, aws.NewConfig().WithRegion(opts.Region))
 
 	var toDelete []*launchTemplate // Paged call, defer deletion until we have the whole list.
@@ -43,7 +44,7 @@ func (LaunchTemplates) MarkAndSweep(opts Options, set *Set) error {
 				Name:    *lt.LaunchTemplateName,
 			}
 			if set.Mark(l) {
-				logrus.Warningf("%s: deleting %T: %s", l.ARN(), lt, l.Name)
+				logger.Warningf("%s: deleting %T: %s", l.ARN(), lt, l.Name)
 				toDelete = append(toDelete, l)
 			}
 		}
@@ -60,7 +61,7 @@ func (LaunchTemplates) MarkAndSweep(opts Options, set *Set) error {
 		}
 
 		if _, err := svc.DeleteLaunchTemplate(deleteReq); err != nil {
-			logrus.Warningf("%s: delete failed: %v", lt.ARN(), err)
+			logger.Warningf("%s: delete failed: %v", lt.ARN(), err)
 		}
 	}
 

--- a/aws-janitor/resources/launch_templates.go
+++ b/aws-janitor/resources/launch_templates.go
@@ -45,7 +45,9 @@ func (LaunchTemplates) MarkAndSweep(opts Options, set *Set) error {
 			}
 			if set.Mark(l) {
 				logger.Warningf("%s: deleting %T: %s", l.ARN(), lt, l.Name)
-				toDelete = append(toDelete, l)
+				if !opts.DryRun {
+					toDelete = append(toDelete, l)
+				}
 			}
 		}
 		return true

--- a/aws-janitor/resources/launch_templates.go
+++ b/aws-janitor/resources/launch_templates.go
@@ -21,7 +21,6 @@ import (
 	"time"
 
 	"github.com/aws/aws-sdk-go/aws"
-	"github.com/aws/aws-sdk-go/aws/session"
 	"github.com/aws/aws-sdk-go/service/ec2"
 	"github.com/pkg/errors"
 	"github.com/sirupsen/logrus"
@@ -30,16 +29,16 @@ import (
 // LaunchTemplates https://docs.aws.amazon.com/sdk-for-go/api/service/ec2/#EC2.DescribeLaunchTemplates
 type LaunchTemplates struct{}
 
-func (LaunchTemplates) MarkAndSweep(sess *session.Session, acct string, region string, set *Set) error {
-	svc := ec2.New(sess, &aws.Config{Region: aws.String(region)})
+func (LaunchTemplates) MarkAndSweep(opts Options, set *Set) error {
+	svc := ec2.New(opts.Session, aws.NewConfig().WithRegion(opts.Region))
 
 	var toDelete []*launchTemplate // Paged call, defer deletion until we have the whole list.
 
 	pageFunc := func(page *ec2.DescribeLaunchTemplatesOutput, _ bool) bool {
 		for _, lt := range page.LaunchTemplates {
 			l := &launchTemplate{
-				Account: acct,
-				Region:  region,
+				Account: opts.Account,
+				Region:  opts.Region,
 				ID:      *lt.LaunchTemplateId,
 				Name:    *lt.LaunchTemplateName,
 			}
@@ -68,8 +67,8 @@ func (LaunchTemplates) MarkAndSweep(sess *session.Session, acct string, region s
 	return nil
 }
 
-func (LaunchTemplates) ListAll(sess *session.Session, acct, region string) (*Set, error) {
-	c := ec2.New(sess, aws.NewConfig().WithRegion(region))
+func (LaunchTemplates) ListAll(opts Options) (*Set, error) {
+	c := ec2.New(opts.Session, aws.NewConfig().WithRegion(opts.Region))
 	set := NewSet(0)
 	input := &ec2.DescribeLaunchTemplatesInput{}
 
@@ -77,8 +76,8 @@ func (LaunchTemplates) ListAll(sess *session.Session, acct, region string) (*Set
 		now := time.Now()
 		for _, lt := range lts.LaunchTemplates {
 			arn := launchTemplate{
-				Account: acct,
-				Region:  region,
+				Account: opts.Account,
+				Region:  opts.Region,
 				ID:      *lt.LaunchTemplateId,
 				Name:    *lt.LaunchTemplateName,
 			}.ARN()
@@ -88,7 +87,7 @@ func (LaunchTemplates) ListAll(sess *session.Session, acct, region string) (*Set
 		return true
 	})
 
-	return set, errors.Wrapf(err, "couldn't list launch templates for %q in %q", acct, region)
+	return set, errors.Wrapf(err, "couldn't list launch templates for %q in %q", opts.Account, opts.Region)
 }
 
 type launchTemplate struct {

--- a/aws-janitor/resources/list.go
+++ b/aws-janitor/resources/list.go
@@ -22,7 +22,7 @@ import (
 
 // Options holds parameters for resource functions.
 type Options struct {
-	Session *session.Session
+	Session *session.Session `json:"-"`
 	Account string
 	Region  string
 }

--- a/aws-janitor/resources/list.go
+++ b/aws-janitor/resources/list.go
@@ -20,15 +20,22 @@ import (
 	"github.com/aws/aws-sdk-go/aws/session"
 )
 
+// Options holds parameters for resource functions.
+type Options struct {
+	Session *session.Session
+	Account string
+	Region  string
+}
+
 type Type interface {
 	// MarkAndSweep queries the resource in a specific region, using
 	// the provided session (which has account-number acct), calling
 	// res.Mark(<resource>) on each resource and deleting
 	// appropriately.
-	MarkAndSweep(sess *session.Session, acct string, region string, res *Set) error
+	MarkAndSweep(opts Options, res *Set) error
 
 	// ListAll queries all the resources this account has access to
-	ListAll(sess *session.Session, acct string, region string) (*Set, error)
+	ListAll(opts Options) (*Set, error)
 }
 
 // AWS resource types known to this script, in dependency order.

--- a/aws-janitor/resources/list.go
+++ b/aws-janitor/resources/list.go
@@ -25,6 +25,9 @@ type Options struct {
 	Session *session.Session `json:"-"`
 	Account string
 	Region  string
+
+	// Whether to actually delete resources, or just report what would be deleted.
+	DryRun bool
 }
 
 type Type interface {

--- a/aws-janitor/resources/nat_gateway.go
+++ b/aws-janitor/resources/nat_gateway.go
@@ -46,6 +46,10 @@ func (NATGateway) MarkAndSweep(opts Options, set *Set) error {
 			}
 
 			if set.Mark(g) {
+				logger.Warningf("%s: deleting %T: %s", g.ARN(), gw, g.ID)
+				if opts.DryRun {
+					continue
+				}
 				inp := &ec2.DeleteNatGatewayInput{NatGatewayId: gw.NatGatewayId}
 				if _, err := svc.DeleteNatGateway(inp); err != nil {
 					logger.Warningf("%s: delete failed: %v", g.ARN(), err)

--- a/aws-janitor/resources/nat_gateway.go
+++ b/aws-janitor/resources/nat_gateway.go
@@ -33,6 +33,7 @@ type NATGateway struct{}
 
 // MarkAndSweep looks at the provided set, and removes resources older than its TTL that have been previously tagged.
 func (NATGateway) MarkAndSweep(opts Options, set *Set) error {
+	logger := logrus.WithField("options", opts)
 	svc := ec2.New(opts.Session, aws.NewConfig().WithRegion(opts.Region))
 
 	inp := &ec2.DescribeNatGatewaysInput{}
@@ -47,7 +48,7 @@ func (NATGateway) MarkAndSweep(opts Options, set *Set) error {
 			if set.Mark(g) {
 				inp := &ec2.DeleteNatGatewayInput{NatGatewayId: gw.NatGatewayId}
 				if _, err := svc.DeleteNatGateway(inp); err != nil {
-					logrus.Warningf("%s: delete failed: %v", g.ARN(), err)
+					logger.Warningf("%s: delete failed: %v", g.ARN(), err)
 				}
 			}
 		}

--- a/aws-janitor/resources/network_interface.go
+++ b/aws-janitor/resources/network_interface.go
@@ -21,7 +21,6 @@ import (
 	"time"
 
 	"github.com/aws/aws-sdk-go/aws"
-	"github.com/aws/aws-sdk-go/aws/session"
 	"github.com/aws/aws-sdk-go/service/ec2"
 	"github.com/pkg/errors"
 	"github.com/sirupsen/logrus"
@@ -31,14 +30,14 @@ import (
 
 type NetworkInterfaces struct{}
 
-func (NetworkInterfaces) MarkAndSweep(sess *session.Session, account string, region string, set *Set) error {
-	svc := ec2.New(sess, &aws.Config{Region: aws.String(region)})
+func (NetworkInterfaces) MarkAndSweep(opts Options, set *Set) error {
+	svc := ec2.New(opts.Session, aws.NewConfig().WithRegion(opts.Region))
 
 	var toDelete []*networkInterface // Paged call, defer deletion until we have the whole list.
 
 	pageFunc := func(page *ec2.DescribeNetworkInterfacesOutput, _ bool) bool {
 		for _, eni := range page.NetworkInterfaces {
-			a := &networkInterface{Region: region, Account: account, ID: *eni.NetworkInterfaceId}
+			a := &networkInterface{Region: opts.Region, Account: opts.Account, ID: *eni.NetworkInterfaceId}
 			if eni.Attachment != nil {
 				a.AttachmentID = *eni.Attachment.AttachmentId
 			}
@@ -76,8 +75,8 @@ func (NetworkInterfaces) MarkAndSweep(sess *session.Session, account string, reg
 	return nil
 }
 
-func (NetworkInterfaces) ListAll(sess *session.Session, acct, region string) (*Set, error) {
-	c := ec2.New(sess, aws.NewConfig().WithRegion(region))
+func (NetworkInterfaces) ListAll(opts Options) (*Set, error) {
+	c := ec2.New(opts.Session, aws.NewConfig().WithRegion(opts.Region))
 	set := NewSet(0)
 	input := &ec2.DescribeNetworkInterfacesInput{}
 
@@ -85,8 +84,8 @@ func (NetworkInterfaces) ListAll(sess *session.Session, acct, region string) (*S
 		now := time.Now()
 		for _, eni := range enis.NetworkInterfaces {
 			arn := networkInterface{
-				Region:  region,
-				Account: acct,
+				Region:  opts.Region,
+				Account: opts.Account,
 				ID:      aws.StringValue(eni.NetworkInterfaceId),
 			}.ARN()
 			set.firstSeen[arn] = now
@@ -95,7 +94,7 @@ func (NetworkInterfaces) ListAll(sess *session.Session, acct, region string) (*S
 		return true
 	})
 
-	return set, errors.Wrapf(err, "couldn't describe network interfaces for %q in %q", acct, region)
+	return set, errors.Wrapf(err, "couldn't describe network interfaces for %q in %q", opts.Account, opts.Region)
 }
 
 type networkInterface struct {

--- a/aws-janitor/resources/network_interface.go
+++ b/aws-janitor/resources/network_interface.go
@@ -44,7 +44,9 @@ func (NetworkInterfaces) MarkAndSweep(opts Options, set *Set) error {
 			}
 			if set.Mark(a) {
 				logger.Warningf("%s: deleting %T", a.ARN(), a)
-				toDelete = append(toDelete, a)
+				if !opts.DryRun {
+					toDelete = append(toDelete, a)
+				}
 			}
 		}
 		return true

--- a/aws-janitor/resources/route53.go
+++ b/aws-janitor/resources/route53.go
@@ -99,7 +99,9 @@ func (Route53ResourceRecordSets) MarkAndSweep(opts Options, set *Set) error {
 					o := &route53ResourceRecordSet{zone: z, obj: rrs}
 					if set.Mark(o) {
 						logger.Warningf("%s: deleting %T: %s", o.ARN(), rrs, *rrs.Name)
-						toDelete = append(toDelete, o)
+						if !opts.DryRun {
+							toDelete = append(toDelete, o)
+						}
 					}
 				}
 				return true

--- a/aws-janitor/resources/route_tables.go
+++ b/aws-janitor/resources/route_tables.go
@@ -55,6 +55,11 @@ func (RouteTables) MarkAndSweep(opts Options, set *Set) error {
 
 		r := &routeTable{Account: opts.Account, Region: opts.Region, ID: *rt.RouteTableId}
 		if set.Mark(r) {
+			logger.Warningf("%s: deleting %T: %s", r.ARN(), rt, r.ID)
+			if opts.DryRun {
+				continue
+			}
+
 			for _, assoc := range rt.Associations {
 				logger.Infof("%s: disassociating from %s", r.ARN(), *assoc.SubnetId)
 
@@ -66,8 +71,6 @@ func (RouteTables) MarkAndSweep(opts Options, set *Set) error {
 					logger.Warningf("%s: disassociation from subnet %s failed: %v", r.ARN(), *assoc.SubnetId, err)
 				}
 			}
-
-			logger.Warningf("%s: deleting %T: %s", r.ARN(), rt, r.ID)
 
 			deleteReq := &ec2.DeleteRouteTableInput{
 				RouteTableId: rt.RouteTableId,

--- a/aws-janitor/resources/security_groups.go
+++ b/aws-janitor/resources/security_groups.go
@@ -68,7 +68,9 @@ func (SecurityGroups) MarkAndSweep(opts Options, set *Set) error {
 		addRefs(egress, *sg.GroupId, opts.Account, sg.IpPermissionsEgress)
 		if set.Mark(s) {
 			logger.Warningf("%s: deleting %T: %s", s.ARN(), sg, s.ID)
-			toDelete = append(toDelete, s)
+			if !opts.DryRun {
+				toDelete = append(toDelete, s)
+			}
 		}
 	}
 

--- a/aws-janitor/resources/set.go
+++ b/aws-janitor/resources/set.go
@@ -62,7 +62,7 @@ func (s *Set) GetARNs() []string {
 
 func LoadSet(sess *session.Session, p *s3path.Path, ttl time.Duration) (*Set, error) {
 	s := NewSet(ttl)
-	svc := s3.New(sess, &aws.Config{Region: aws.String(p.Region)})
+	svc := s3.New(sess, aws.NewConfig().WithRegion(p.Region))
 
 	resp, err := svc.GetObject(&s3.GetObjectInput{Bucket: aws.String(p.Bucket), Key: aws.String(p.Key)})
 	if err != nil {
@@ -87,7 +87,7 @@ func (s *Set) Save(sess *session.Session, p *s3path.Path) error {
 		return err
 	}
 
-	svc := s3.New(sess, &aws.Config{Region: aws.String(p.Region)})
+	svc := s3.New(sess, aws.NewConfig().WithRegion(p.Region))
 
 	_, err = svc.PutObject(&s3.PutObjectInput{
 		Bucket:       aws.String(p.Bucket),

--- a/aws-janitor/resources/subnets.go
+++ b/aws-janitor/resources/subnets.go
@@ -21,7 +21,6 @@ import (
 	"time"
 
 	"github.com/aws/aws-sdk-go/aws"
-	"github.com/aws/aws-sdk-go/aws/session"
 	"github.com/aws/aws-sdk-go/service/ec2"
 	"github.com/pkg/errors"
 	"github.com/sirupsen/logrus"
@@ -30,8 +29,8 @@ import (
 // Subnets: https://docs.aws.amazon.com/sdk-for-go/api/service/ec2/#EC2.DescribeSubnets
 type Subnets struct{}
 
-func (Subnets) MarkAndSweep(sess *session.Session, acct string, region string, set *Set) error {
-	svc := ec2.New(sess, &aws.Config{Region: aws.String(region)})
+func (Subnets) MarkAndSweep(opts Options, set *Set) error {
+	svc := ec2.New(opts.Session, aws.NewConfig().WithRegion(opts.Region))
 
 	descReq := &ec2.DescribeSubnetsInput{
 		Filters: []*ec2.Filter{
@@ -48,7 +47,7 @@ func (Subnets) MarkAndSweep(sess *session.Session, acct string, region string, s
 	}
 
 	for _, sub := range resp.Subnets {
-		s := &subnet{Account: acct, Region: region, ID: *sub.SubnetId}
+		s := &subnet{Account: opts.Account, Region: opts.Region, ID: *sub.SubnetId}
 		if set.Mark(s) {
 			logrus.Warningf("%s: deleting %T: %s", s.ARN(), sub, s.ID)
 			if _, err := svc.DeleteSubnet(&ec2.DeleteSubnetInput{SubnetId: sub.SubnetId}); err != nil {
@@ -60,8 +59,8 @@ func (Subnets) MarkAndSweep(sess *session.Session, acct string, region string, s
 	return nil
 }
 
-func (Subnets) ListAll(sess *session.Session, acct, region string) (*Set, error) {
-	svc := ec2.New(sess, &aws.Config{Region: aws.String(region)})
+func (Subnets) ListAll(opts Options) (*Set, error) {
+	svc := ec2.New(opts.Session, aws.NewConfig().WithRegion(opts.Region))
 	set := NewSet(0)
 	input := &ec2.DescribeSubnetsInput{}
 
@@ -70,14 +69,14 @@ func (Subnets) ListAll(sess *session.Session, acct, region string) (*Set, error)
 	now := time.Now()
 	for _, sn := range subnets.Subnets {
 		arn := subnet{
-			Account: acct,
-			Region:  region,
+			Account: opts.Account,
+			Region:  opts.Region,
 			ID:      *sn.SubnetId,
 		}.ARN()
 		set.firstSeen[arn] = now
 	}
 
-	return set, errors.Wrapf(err, "couldn't describe subnets for %q in %q", acct, region)
+	return set, errors.Wrapf(err, "couldn't describe subnets for %q in %q", opts.Account, opts.Region)
 }
 
 type subnet struct {

--- a/aws-janitor/resources/subnets.go
+++ b/aws-janitor/resources/subnets.go
@@ -30,6 +30,7 @@ import (
 type Subnets struct{}
 
 func (Subnets) MarkAndSweep(opts Options, set *Set) error {
+	logger := logrus.WithField("options", opts)
 	svc := ec2.New(opts.Session, aws.NewConfig().WithRegion(opts.Region))
 
 	descReq := &ec2.DescribeSubnetsInput{
@@ -49,9 +50,9 @@ func (Subnets) MarkAndSweep(opts Options, set *Set) error {
 	for _, sub := range resp.Subnets {
 		s := &subnet{Account: opts.Account, Region: opts.Region, ID: *sub.SubnetId}
 		if set.Mark(s) {
-			logrus.Warningf("%s: deleting %T: %s", s.ARN(), sub, s.ID)
+			logger.Warningf("%s: deleting %T: %s", s.ARN(), sub, s.ID)
 			if _, err := svc.DeleteSubnet(&ec2.DeleteSubnetInput{SubnetId: sub.SubnetId}); err != nil {
-				logrus.Warningf("%s: delete failed: %v", s.ARN(), err)
+				logger.Warningf("%s: delete failed: %v", s.ARN(), err)
 			}
 		}
 	}

--- a/aws-janitor/resources/subnets.go
+++ b/aws-janitor/resources/subnets.go
@@ -51,6 +51,9 @@ func (Subnets) MarkAndSweep(opts Options, set *Set) error {
 		s := &subnet{Account: opts.Account, Region: opts.Region, ID: *sub.SubnetId}
 		if set.Mark(s) {
 			logger.Warningf("%s: deleting %T: %s", s.ARN(), sub, s.ID)
+			if opts.DryRun {
+				continue
+			}
 			if _, err := svc.DeleteSubnet(&ec2.DeleteSubnetInput{SubnetId: sub.SubnetId}); err != nil {
 				logger.Warningf("%s: delete failed: %v", s.ARN(), err)
 			}

--- a/aws-janitor/resources/volumes.go
+++ b/aws-janitor/resources/volumes.go
@@ -40,7 +40,9 @@ func (Volumes) MarkAndSweep(opts Options, set *Set) error {
 			v := &volume{Account: opts.Account, Region: opts.Region, ID: *vol.VolumeId}
 			if set.Mark(v) {
 				logger.Warningf("%s: deleting %T: %s", v.ARN(), vol, v.ID)
-				toDelete = append(toDelete, v)
+				if !opts.DryRun {
+					toDelete = append(toDelete, v)
+				}
 			}
 		}
 		return true

--- a/aws-janitor/resources/vpcs.go
+++ b/aws-janitor/resources/vpcs.go
@@ -50,7 +50,9 @@ func (VPCs) MarkAndSweep(opts Options, set *Set) error {
 		v := &vpc{Account: opts.Account, Region: opts.Region, ID: *vp.VpcId}
 		if set.Mark(v) {
 			logger.Warningf("%s: deleting %T: %s", v.ARN(), vp, v.ID)
-
+			if opts.DryRun {
+				continue
+			}
 			if vp.DhcpOptionsId != nil && *vp.DhcpOptionsId != "default" {
 				disReq := &ec2.AssociateDhcpOptionsInput{
 					VpcId:         vp.VpcId,

--- a/cmd/aws-janitor-boskos/main.go
+++ b/cmd/aws-janitor-boskos/main.go
@@ -43,6 +43,7 @@ var (
 	sweepSleep         = flag.String("sweep-sleep", "30s", "The duration to pause between sweeps")
 	sweepSleepDuration time.Duration
 	logLevel           = flag.String("log-level", "info", fmt.Sprintf("Log level is one of %v.", logrus.AllLevels))
+	dryRun             = flag.Bool("dry-run", false, "If set, don't delete any resources, only log what would be done")
 )
 
 const (
@@ -121,7 +122,7 @@ func cleanResource(res *common.Resource) error {
 	start := time.Now()
 
 	for i := 0; i < *sweepCount; i++ {
-		if err := resources.CleanAll(s, *region); err != nil {
+		if err := resources.CleanAll(s, *region, *dryRun); err != nil {
 			if i == *sweepCount-1 {
 				logrus.WithError(err).Warningf("Failed to clean resource %q", res.Name)
 			}

--- a/cmd/aws-janitor/main.go
+++ b/cmd/aws-janitor/main.go
@@ -38,6 +38,7 @@ var (
 	path     = flag.String("path", "", "S3 path for mark data (required when -all=false)")
 	cleanAll = flag.Bool("all", false, "Clean all resources (ignores -path)")
 	logLevel = flag.String("log-level", "info", fmt.Sprintf("Log level is one of %v.", logrus.AllLevels))
+	dryRun   = flag.Bool("dry-run", false, "If set, don't delete any resources, only log what would be done")
 )
 
 func main() {
@@ -57,7 +58,7 @@ func main() {
 	sess := session.Must(session.NewSessionWithOptions(session.Options{Config: aws.Config{MaxRetries: aws.Int(100)}}))
 
 	if *cleanAll {
-		if err := resources.CleanAll(sess, *region); err != nil {
+		if err := resources.CleanAll(sess, *region, *dryRun); err != nil {
 			logrus.Fatalf("Error cleaning all resources: %v", err)
 		}
 	} else if err := markAndSweep(sess, *region); err != nil {
@@ -96,6 +97,7 @@ func markAndSweep(sess *session.Session, region string) error {
 	opts := resources.Options{
 		Session: sess,
 		Account: acct,
+		DryRun:  *dryRun,
 	}
 	for _, region := range regionList {
 		opts.Region = region

--- a/cmd/aws-janitor/main.go
+++ b/cmd/aws-janitor/main.go
@@ -93,16 +93,22 @@ func markAndSweep(sess *session.Session, region string) error {
 		return errors.Wrapf(err, "Error loading %q", *path)
 	}
 
+	opts := resources.Options{
+		Session: sess,
+		Account: acct,
+	}
 	for _, region := range regionList {
+		opts.Region = region
 		for _, typ := range resources.RegionalTypeList {
-			if err := typ.MarkAndSweep(sess, acct, region, res); err != nil {
+			if err := typ.MarkAndSweep(opts, res); err != nil {
 				return errors.Wrapf(err, "Error sweeping %T", typ)
 			}
 		}
 	}
 
+	opts.Region = regions.Default
 	for _, typ := range resources.GlobalTypeList {
-		if err := typ.MarkAndSweep(sess, acct, regions.Default, res); err != nil {
+		if err := typ.MarkAndSweep(opts, res); err != nil {
 			return errors.Wrapf(err, "Error sweeping %T", typ)
 		}
 	}

--- a/cmd/aws-resources-list/main.go
+++ b/cmd/aws-resources-list/main.go
@@ -35,7 +35,7 @@ var (
 func listResources(res resources.Type, sess *session.Session, acct string, regions []string) {
 	fmt.Printf("==%T==\n", res)
 	for _, region := range regions {
-		set, err := res.ListAll(sess, acct, region)
+		set, err := res.ListAll(resources.Options{Session: sess, Account: acct, Region: region})
 		if err != nil {
 			fmt.Fprintf(os.Stderr, "error listing %T: %v\n", res, err)
 			continue

--- a/cmd/aws-resources-list/main.go
+++ b/cmd/aws-resources-list/main.go
@@ -35,7 +35,7 @@ var (
 func listResources(res resources.Type, sess *session.Session, acct string, regions []string) {
 	fmt.Printf("==%T==\n", res)
 	for _, region := range regions {
-		set, err := res.ListAll(resources.Options{Session: sess, Account: acct, Region: region})
+		set, err := res.ListAll(resources.Options{Session: sess, Account: acct, Region: region, DryRun: true})
 		if err != nil {
 			fmt.Fprintf(os.Stderr, "error listing %T: %v\n", res, err)
 			continue


### PR DESCRIPTION
We'd like to use the AWS janitor in some additional places, but the lack of a "dry-run" functionality to validate what it'll do makes me nervous.

I started by refactoring the various resources methods to take an `Options` struct. The main reason I did this instead of just adding a dry-run boolean is that I intend to further extend this with additional configuration (such as include/exclude labels).

The dry-run functionality just builds on this new Options struct.

/assign @detiber 