### PR TITLE
aws-janitor: validate region flag

### DIFF
--- a/aws-janitor/resources/clean.go
+++ b/aws-janitor/resources/clean.go
@@ -38,14 +38,9 @@ func CleanAll(sess *session.Session, region string) error {
 	}
 	logrus.Debugf("Account: %s", acct)
 
-	var regionList []string
-	if region == "" {
-		regionList, err = regions.GetAll(sess)
-		if err != nil {
-			return errors.Wrap(err, "Couldn't retrieve list of regions")
-		}
-	} else {
-		regionList = []string{region}
+	regionList, err := regions.ParseRegion(sess, region)
+	if err != nil {
+		return err
 	}
 	logrus.Infof("Regions: %s", strings.Join(regionList, ", "))
 

--- a/cmd/aws-janitor/main.go
+++ b/cmd/aws-janitor/main.go
@@ -77,14 +77,9 @@ func markAndSweep(sess *session.Session, region string) error {
 	}
 	logrus.Debugf("account: %s", acct)
 
-	var regionList []string
-	if region == "" {
-		regionList, err = regions.GetAll(sess)
-		if err != nil {
-			return errors.Wrap(err, "Error getting available regions")
-		}
-	} else {
-		regionList = []string{region}
+	regionList, err := regions.ParseRegion(sess, region)
+	if err != nil {
+		return err
 	}
 	logrus.Infof("Regions: %+v", regionList)
 

--- a/cmd/aws-resources-list/main.go
+++ b/cmd/aws-resources-list/main.go
@@ -20,7 +20,6 @@ import (
 	"flag"
 	"fmt"
 	"os"
-	"sort"
 
 	"github.com/aws/aws-sdk-go/aws/session"
 	"sigs.k8s.io/boskos/aws-janitor/account"
@@ -53,19 +52,14 @@ func main() {
 	session := session.Must(session.NewSession())
 	acct, err := account.GetAccount(session, *region)
 	if err != nil {
-		fmt.Fprintf(os.Stderr, "error retrieving account: %v", err)
+		fmt.Fprintf(os.Stderr, "error retrieving account: %v\n", err)
 		os.Exit(1)
 	}
 
-	var regionList []string
-	if *region == "" {
-		regionList, err = regions.GetAll(session)
-		if err != nil {
-			fmt.Fprintf(os.Stderr, "couldn't retrieve list of regions: %v", err)
-		}
-		sort.Strings(regionList)
-	} else {
-		regionList = []string{*region}
+	regionList, err := regions.ParseRegion(session, *region)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "error parsing region: %v\n", err)
+		os.Exit(1)
 	}
 
 	for _, r := range resources.RegionalTypeList {


### PR DESCRIPTION
While testing https://github.com/kubernetes-sigs/boskos/pull/47 I couldn't figure out why certain operations were getting stuck, until I realized I wasn't using a valid region name.

This PR adds some validation to fail-fast if an invalid region is used (e.g. `us-west2` instead of `us-west-2`).