### PR TITLE
aws-janitor: use creation timestamp when available

### DIFF
--- a/aws-janitor/resources/asg.go
+++ b/aws-janitor/resources/asg.go
@@ -38,7 +38,7 @@ func (AutoScalingGroups) MarkAndSweep(opts Options, set *Set) error {
 	pageFunc := func(page *autoscaling.DescribeAutoScalingGroupsOutput, _ bool) bool {
 		for _, asg := range page.AutoScalingGroups {
 			a := &autoScalingGroup{ID: *asg.AutoScalingGroupARN, Name: *asg.AutoScalingGroupName}
-			if set.Mark(a) {
+			if set.Mark(a, asg.CreatedTime) {
 				logger.Warningf("%s: deleting %T: %s", a.ARN(), asg, a.Name)
 				if !opts.DryRun {
 					toDelete = append(toDelete, a)

--- a/aws-janitor/resources/cloud_formation_stacks.go
+++ b/aws-janitor/resources/cloud_formation_stacks.go
@@ -47,7 +47,7 @@ func (CloudFormationStacks) MarkAndSweep(opts Options, set *Set) error {
 				id:   aws.StringValue(stack.StackId),
 				name: aws.StringValue(stack.StackName),
 			}
-			if set.Mark(o) {
+			if set.Mark(o, stack.CreationTime) {
 				logger.Warningf("%s: deleting %T: %s", o.ARN(), o, o.name)
 				if !opts.DryRun {
 					toDelete = append(toDelete, o)

--- a/aws-janitor/resources/dhcp_options.go
+++ b/aws-janitor/resources/dhcp_options.go
@@ -73,7 +73,7 @@ func (DHCPOptions) MarkAndSweep(opts Options, set *Set) error {
 		}
 
 		dh := &dhcpOption{Account: opts.Account, Region: opts.Region, ID: *dhcp.DhcpOptionsId}
-		if set.Mark(dh) {
+		if set.Mark(dh, nil) {
 			logger.Warningf("%s: deleting %T: %s", dh.ARN(), dhcp, dh.ID)
 			if opts.DryRun {
 				continue

--- a/aws-janitor/resources/efs.go
+++ b/aws-janitor/resources/efs.go
@@ -51,7 +51,7 @@ func (ElasticFileSystems) MarkAndSweep(opts Options, set *Set) error {
 			f := &elasticFileSystem{
 				ID: *fs.FileSystemId,
 			}
-			if set.Mark(f) {
+			if set.Mark(f, fs.CreationTime) {
 				logger.Warningf("%s: deleting %T: %s", f.ARN(), fs, *fs.Name)
 				if !opts.DryRun {
 					fileSystemsToDelete = append(fileSystemsToDelete, f)

--- a/aws-janitor/resources/elb.go
+++ b/aws-janitor/resources/elb.go
@@ -38,7 +38,7 @@ func (ClassicLoadBalancers) MarkAndSweep(opts Options, set *Set) error {
 	pageFunc := func(page *elb.DescribeLoadBalancersOutput, _ bool) bool {
 		for _, lb := range page.LoadBalancerDescriptions {
 			a := &classicLoadBalancer{region: opts.Region, account: opts.Account, name: *lb.LoadBalancerName, dnsName: *lb.DNSName}
-			if set.Mark(a) {
+			if set.Mark(a, lb.CreatedTime) {
 				logger.Warningf("%s: deleting %T: %s", a.ARN(), lb, a.name)
 				if !opts.DryRun {
 					toDelete = append(toDelete, a)

--- a/aws-janitor/resources/elbv2.go
+++ b/aws-janitor/resources/elbv2.go
@@ -38,7 +38,7 @@ func (LoadBalancers) MarkAndSweep(opts Options, set *Set) error {
 	pageFunc := func(page *elbv2.DescribeLoadBalancersOutput, _ bool) bool {
 		for _, lb := range page.LoadBalancers {
 			a := &loadBalancer{arn: *lb.LoadBalancerArn}
-			if set.Mark(a) {
+			if set.Mark(a, lb.CreatedTime) {
 				logger.Warningf("%s: deleting %T: %s", a.ARN(), lb, *lb.LoadBalancerName)
 				if !opts.DryRun {
 					toDelete = append(toDelete, a)

--- a/aws-janitor/resources/iam_instance_profiles.go
+++ b/aws-janitor/resources/iam_instance_profiles.go
@@ -55,7 +55,7 @@ func (IAMInstanceProfiles) MarkAndSweep(opts Options, set *Set) error {
 			}
 
 			o := &iamInstanceProfile{profile: p}
-			if set.Mark(o) {
+			if set.Mark(o, p.CreateDate) {
 				logger.Warningf("%s: deleting %T: %s", o.ARN(), o, o.ARN())
 				if !opts.DryRun {
 					toDelete = append(toDelete, o)

--- a/aws-janitor/resources/iam_roles.go
+++ b/aws-janitor/resources/iam_roles.go
@@ -63,7 +63,7 @@ func (IAMRoles) MarkAndSweep(opts Options, set *Set) error {
 			}
 
 			l := &iamRole{arn: aws.StringValue(r.Arn), roleID: aws.StringValue(r.RoleId), roleName: aws.StringValue(r.RoleName)}
-			if set.Mark(l) {
+			if set.Mark(l, r.CreateDate) {
 				logger.Warningf("%s: deleting %T: %s", l.ARN(), r, l.roleName)
 				if !opts.DryRun {
 					toDelete = append(toDelete, l)

--- a/aws-janitor/resources/instance.go
+++ b/aws-janitor/resources/instance.go
@@ -54,8 +54,8 @@ func (Instances) MarkAndSweep(opts Options, set *Set) error {
 					Region:     opts.Region,
 					InstanceID: *inst.InstanceId,
 				}
-
-				if set.Mark(i) {
+				// Instances don't have a creation date, but launch time is better than nothing.
+				if set.Mark(i, inst.LaunchTime) {
 					logger.Warningf("%s: deleting %T: %s", i.ARN(), inst, i.InstanceID)
 					if !opts.DryRun {
 						toDelete = append(toDelete, inst.InstanceId)

--- a/aws-janitor/resources/launch_configs.go
+++ b/aws-janitor/resources/launch_configs.go
@@ -37,7 +37,7 @@ func (LaunchConfigurations) MarkAndSweep(opts Options, set *Set) error {
 	pageFunc := func(page *autoscaling.DescribeLaunchConfigurationsOutput, _ bool) bool {
 		for _, lc := range page.LaunchConfigurations {
 			l := &launchConfiguration{ID: *lc.LaunchConfigurationARN, Name: *lc.LaunchConfigurationName}
-			if set.Mark(l) {
+			if set.Mark(l, lc.CreatedTime) {
 				logger.Warningf("%s: deleting %T: %s", l.ARN(), lc, l.Name)
 				if !opts.DryRun {
 					toDelete = append(toDelete, l)

--- a/aws-janitor/resources/launch_templates.go
+++ b/aws-janitor/resources/launch_templates.go
@@ -43,7 +43,7 @@ func (LaunchTemplates) MarkAndSweep(opts Options, set *Set) error {
 				ID:      *lt.LaunchTemplateId,
 				Name:    *lt.LaunchTemplateName,
 			}
-			if set.Mark(l) {
+			if set.Mark(l, lt.CreateTime) {
 				logger.Warningf("%s: deleting %T: %s", l.ARN(), lt, l.Name)
 				if !opts.DryRun {
 					toDelete = append(toDelete, l)

--- a/aws-janitor/resources/nat_gateway.go
+++ b/aws-janitor/resources/nat_gateway.go
@@ -45,7 +45,7 @@ func (NATGateway) MarkAndSweep(opts Options, set *Set) error {
 				ID:      *gw.NatGatewayId,
 			}
 
-			if set.Mark(g) {
+			if set.Mark(g, gw.CreateTime) {
 				logger.Warningf("%s: deleting %T: %s", g.ARN(), gw, g.ID)
 				if opts.DryRun {
 					continue

--- a/aws-janitor/resources/route53.go
+++ b/aws-janitor/resources/route53.go
@@ -85,7 +85,7 @@ func route53ResourceRecordSetsForZone(logger logrus.FieldLogger, svc *route53.Ro
 			}
 
 			o := &route53ResourceRecordSet{zone: zone, obj: rrs}
-			if set.Mark(o) {
+			if set.Mark(o, nil) {
 				logger.Warningf("%s: deleting %T: %s", o.ARN(), rrs, *rrs.Name)
 			}
 		}

--- a/aws-janitor/resources/route_tables.go
+++ b/aws-janitor/resources/route_tables.go
@@ -54,7 +54,7 @@ func (RouteTables) MarkAndSweep(opts Options, set *Set) error {
 		}
 
 		r := &routeTable{Account: opts.Account, Region: opts.Region, ID: *rt.RouteTableId}
-		if set.Mark(r) {
+		if set.Mark(r, nil) {
 			logger.Warningf("%s: deleting %T: %s", r.ARN(), rt, r.ID)
 			if opts.DryRun {
 				continue

--- a/aws-janitor/resources/security_groups.go
+++ b/aws-janitor/resources/security_groups.go
@@ -66,7 +66,7 @@ func (SecurityGroups) MarkAndSweep(opts Options, set *Set) error {
 		s := &securityGroup{Account: opts.Account, Region: opts.Region, ID: *sg.GroupId}
 		addRefs(ingress, *sg.GroupId, opts.Account, sg.IpPermissions)
 		addRefs(egress, *sg.GroupId, opts.Account, sg.IpPermissionsEgress)
-		if set.Mark(s) {
+		if set.Mark(s, nil) {
 			logger.Warningf("%s: deleting %T: %s", s.ARN(), sg, s.ID)
 			if !opts.DryRun {
 				toDelete = append(toDelete, s)

--- a/aws-janitor/resources/set_test.go
+++ b/aws-janitor/resources/set_test.go
@@ -1,0 +1,154 @@
+/*
+Copyright 2020 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package resources
+
+import (
+	"testing"
+	"time"
+)
+
+type fakeResource struct {
+	Name string
+}
+
+func (f fakeResource) ARN() string {
+	return f.Name
+}
+
+func (f fakeResource) ResourceKey() string {
+	return f.Name
+}
+
+func absDuration(d time.Duration) time.Duration {
+	if d < 0 {
+		return -d
+	}
+	return d
+}
+
+func TestMarkCreationTimes(t *testing.T) {
+	for _, deleteAll := range []bool{false, true} {
+		ttl := time.Hour
+
+		now := time.Now()
+		sixHoursAgo := now.Add(-6 * time.Hour)
+		threeHoursAgo := now.Add(-3 * time.Hour)
+		tenMinutesAgo := now.Add(-10 * time.Minute)
+		epoch := time.Unix(0, 0)
+		unset := time.Time{}
+
+		if deleteAll {
+			ttl = 0
+		}
+		s := NewSet(ttl)
+
+		prevSeenNotExpired := fakeResource{Name: "PreviouslySeenNotExpired"}
+		s.firstSeen[prevSeenNotExpired.ResourceKey()] = tenMinutesAgo
+		prevSeenExpired := fakeResource{Name: "PreviouslySeenExpired"}
+		s.firstSeen[prevSeenExpired.ResourceKey()] = threeHoursAgo
+		prevSeenNewOlderCreateTime := fakeResource{Name: "PreviouslySeenNewOlderCreateTime"}
+		s.firstSeen[prevSeenNewOlderCreateTime.ResourceKey()] = tenMinutesAgo
+		prevSeenNewYoungerCreateTime := fakeResource{Name: "PreviouslySeenNewYoungerCreateTime"}
+		s.firstSeen[prevSeenNewYoungerCreateTime.ResourceKey()] = threeHoursAgo
+
+		for _, tc := range []struct {
+			Resource          fakeResource
+			ShouldDelete      bool
+			CreateTime        *time.Time
+			ExpectedFirstSeen time.Time
+		}{
+			{
+				// New resource, no creation time -> should use time.Now()
+				Resource:          fakeResource{"NoCreateTime"},
+				ShouldDelete:      false,
+				CreateTime:        nil,
+				ExpectedFirstSeen: now,
+			},
+			{
+				Resource:          fakeResource{"EpochCreateTime"},
+				ShouldDelete:      false,
+				CreateTime:        &epoch,
+				ExpectedFirstSeen: now,
+			},
+			{
+				Resource:          fakeResource{"UnsetCreateTime"},
+				ShouldDelete:      false,
+				CreateTime:        &unset,
+				ExpectedFirstSeen: now,
+			},
+			{
+				Resource:          fakeResource{"AlwaysDelete"},
+				ShouldDelete:      true,
+				CreateTime:        &sixHoursAgo,
+				ExpectedFirstSeen: sixHoursAgo,
+			},
+			{
+				Resource:          prevSeenNotExpired,
+				ShouldDelete:      false,
+				CreateTime:        nil,
+				ExpectedFirstSeen: tenMinutesAgo,
+			},
+			{
+				Resource:          prevSeenExpired,
+				ShouldDelete:      true,
+				CreateTime:        nil,
+				ExpectedFirstSeen: threeHoursAgo,
+			},
+			{
+				// If running against an older database, we want to ensure it updates with our new knowledge.
+				Resource:          prevSeenNewOlderCreateTime,
+				ShouldDelete:      true,
+				CreateTime:        &threeHoursAgo,
+				ExpectedFirstSeen: threeHoursAgo,
+			},
+			{
+				// Some resources only have times that can potentially reset to newer times (e.g. startup date)
+				Resource:          prevSeenNewYoungerCreateTime,
+				ShouldDelete:      true,
+				CreateTime:        &tenMinutesAgo,
+				ExpectedFirstSeen: threeHoursAgo,
+			},
+		} {
+			shouldDelete := deleteAll || tc.ShouldDelete
+			delete := s.Mark(tc.Resource, tc.CreateTime)
+			if delete != shouldDelete {
+				t.Errorf("%s: delete: expected=%v, got=%v", tc.Resource.Name, shouldDelete, delete)
+			}
+
+			found := false
+			for _, key := range s.swept {
+				if key == tc.Resource.ResourceKey() {
+					found = true
+					break
+				}
+			}
+			if found != shouldDelete {
+				t.Errorf("%s: resource not found in swept list", tc.Resource.Name)
+			}
+
+			if _, ok := s.marked[tc.Resource.ResourceKey()]; !ok {
+				t.Errorf("%s: not marked", tc.Resource.Name)
+			}
+
+			firstSeen := s.firstSeen[tc.Resource.ResourceKey()]
+			// Give a little leeway for varying values of Time.Now()
+			if absDuration(tc.ExpectedFirstSeen.Sub(firstSeen)) > time.Minute {
+				t.Errorf("%s: firstSeen: expected=%v, got=%v", tc.Resource.Name, tc.ExpectedFirstSeen, firstSeen)
+			}
+		}
+	}
+}

--- a/aws-janitor/resources/snapshots.go
+++ b/aws-janitor/resources/snapshots.go
@@ -43,7 +43,8 @@ func (Snapshots) MarkAndSweep(opts Options, set *Set) error {
 	pageFunc := func(page *ec2.DescribeSnapshotsOutput, _ bool) bool {
 		for _, ss := range page.Snapshots {
 			s := &snapshot{ID: *ss.SnapshotId}
-			if set.Mark(s) {
+			// StartTime is probably close enough to a creation timestamp
+			if set.Mark(s, ss.StartTime) {
 				logger.Warningf("%s: deleting %T", s.ARN(), s)
 				if !opts.DryRun {
 					toDelete = append(toDelete, s)

--- a/aws-janitor/resources/subnets.go
+++ b/aws-janitor/resources/subnets.go
@@ -49,7 +49,7 @@ func (Subnets) MarkAndSweep(opts Options, set *Set) error {
 
 	for _, sub := range resp.Subnets {
 		s := &subnet{Account: opts.Account, Region: opts.Region, ID: *sub.SubnetId}
-		if set.Mark(s) {
+		if set.Mark(s, nil) {
 			logger.Warningf("%s: deleting %T: %s", s.ARN(), sub, s.ID)
 			if opts.DryRun {
 				continue

--- a/aws-janitor/resources/volumes.go
+++ b/aws-janitor/resources/volumes.go
@@ -38,7 +38,7 @@ func (Volumes) MarkAndSweep(opts Options, set *Set) error {
 	pageFunc := func(page *ec2.DescribeVolumesOutput, _ bool) bool {
 		for _, vol := range page.Volumes {
 			v := &volume{Account: opts.Account, Region: opts.Region, ID: *vol.VolumeId}
-			if set.Mark(v) {
+			if set.Mark(v, vol.CreateTime) {
 				logger.Warningf("%s: deleting %T: %s", v.ARN(), vol, v.ID)
 				if !opts.DryRun {
 					toDelete = append(toDelete, v)


### PR DESCRIPTION
Many resources don't have a readily accessible creation timestamp in their metadata, but at least some of them do, so we may as well make use of it when available.

/assign @detiber 
cc @chemikadze