### PR TITLE
OWNERS_ALIASES: Swap out aws-janitor contributors

### DIFF
--- a/OWNERS_ALIASES
+++ b/OWNERS_ALIASES
@@ -1,4 +1,8 @@
 aliases:
   aws-janitor-contributors:
-  - detiber
   - justinsb
+  - richardcase
+  - randomvariable
+
+  aws-janitor-emeritus-contributors:
+  - detiber


### PR DESCRIPTION
@richardcase and @randomvariable are  the active maintainers for https://github.com/kubernetes-sigs/cluster-api-provider-aws at present, with @detiber primarily focused on Equinix atm, so we are swapping places.