### PR TITLE
aws-janitor: support filtering based on tags

### DIFF
--- a/aws-janitor/resources/addresses.go
+++ b/aws-janitor/resources/addresses.go
@@ -41,7 +41,8 @@ func (Addresses) MarkAndSweep(opts Options, set *Set) error {
 
 	for _, addr := range resp.Addresses {
 		a := &address{Account: opts.Account, Region: opts.Region, ID: *addr.AllocationId}
-		if !set.Mark(opts, a, nil, fromEC2Tags(addr.Tags)) {
+		tags := fromEC2Tags(addr.Tags)
+		if !set.Mark(opts, a, nil, tags) {
 			continue
 		}
 		// Since tags and other metadata may not propagate to addresses from their associated instances,
@@ -51,7 +52,7 @@ func (Addresses) MarkAndSweep(opts Options, set *Set) error {
 			continue
 		}
 
-		logger.Warningf("%s: deleting %T: %s", a.ARN(), addr, a.ID)
+		logger.Warningf("%s: deleting %T: %s (%s)", a.ARN(), addr, a.ID, tags[NameTagKey])
 		if opts.DryRun {
 			continue
 		}

--- a/aws-janitor/resources/asg.go
+++ b/aws-janitor/resources/asg.go
@@ -41,9 +41,9 @@ func (AutoScalingGroups) MarkAndSweep(opts Options, set *Set) error {
 				arn:  aws.StringValue(asg.AutoScalingGroupARN),
 				name: aws.StringValue(asg.AutoScalingGroupName),
 			}
-			tags := make([]Tag, len(asg.Tags))
+			tags := make(Tags, len(asg.Tags))
 			for _, t := range asg.Tags {
-				tags = append(tags, NewTag(t.Key, t.Value))
+				tags.Add(t.Key, t.Value)
 			}
 			if !set.Mark(opts, a, asg.CreatedTime, tags) {
 				continue

--- a/aws-janitor/resources/clean.go
+++ b/aws-janitor/resources/clean.go
@@ -21,24 +21,16 @@ import (
 	"strings"
 
 	"github.com/aws/aws-sdk-go/aws/awserr"
-	"github.com/aws/aws-sdk-go/aws/session"
 	"github.com/pkg/errors"
 	"github.com/sirupsen/logrus"
 	kerrors "k8s.io/apimachinery/pkg/util/errors"
-	"sigs.k8s.io/boskos/aws-janitor/account"
 	"sigs.k8s.io/boskos/aws-janitor/regions"
 )
 
 // CleanAll cleans all of the resources for all of the regions visible to
 // the provided AWS session.
-func CleanAll(sess *session.Session, region string, dryRun bool) error {
-	acct, err := account.GetAccount(sess, regions.Default)
-	if err != nil {
-		return errors.Wrap(err, "Failed to retrieve account")
-	}
-	logrus.Debugf("Account: %s", acct)
-
-	regionList, err := regions.ParseRegion(sess, region)
+func CleanAll(opts Options, region string) error {
+	regionList, err := regions.ParseRegion(opts.Session, region)
 	if err != nil {
 		return err
 	}
@@ -46,11 +38,6 @@ func CleanAll(sess *session.Session, region string, dryRun bool) error {
 
 	var errs []error
 
-	opts := Options{
-		Session: sess,
-		Account: acct,
-		DryRun:  dryRun,
-	}
 	for _, r := range regionList {
 		opts.Region = r
 		logger := logrus.WithField("options", opts)

--- a/aws-janitor/resources/cloud_formation_stacks.go
+++ b/aws-janitor/resources/cloud_formation_stacks.go
@@ -17,18 +17,43 @@ limitations under the License.
 package resources
 
 import (
+	"fmt"
 	"time"
 
 	"github.com/aws/aws-sdk-go/aws"
 	cf "github.com/aws/aws-sdk-go/service/cloudformation"
 	"github.com/pkg/errors"
 	"github.com/sirupsen/logrus"
+	kerrors "k8s.io/apimachinery/pkg/util/errors"
 )
 
 // Cloud Formation Stacks
 type CloudFormationStacks struct{}
 
-func (CloudFormationStacks) MarkAndSweep(opts Options, set *Set) error {
+func (CloudFormationStacks) fetchTags(svc *cf.CloudFormation, stackID string) ([]Tag, error) {
+	var tags []Tag
+	var errs []error
+
+	describeErr := svc.DescribeStacksPages(&cf.DescribeStacksInput{StackName: aws.String(stackID)},
+		func(page *cf.DescribeStacksOutput, _ bool) bool {
+			for _, stack := range page.Stacks {
+				if aws.StringValue(stack.StackId) != stackID {
+					errs = append(errs, fmt.Errorf("unexpected stack id in DescribeStacks output: %s", aws.StringValue(stack.StackId)))
+					continue
+				}
+				for _, t := range stack.Tags {
+					tags = append(tags, NewTag(t.Key, t.Value))
+				}
+			}
+			return true
+		})
+	if describeErr != nil {
+		errs = append(errs, describeErr)
+	}
+	return tags, kerrors.NewAggregate(errs)
+}
+
+func (cfs CloudFormationStacks) MarkAndSweep(opts Options, set *Set) error {
 	logger := logrus.WithField("options", opts)
 	svc := cf.New(opts.Session, aws.NewConfig().WithRegion(opts.Region))
 
@@ -47,11 +72,18 @@ func (CloudFormationStacks) MarkAndSweep(opts Options, set *Set) error {
 				arn:  aws.StringValue(stack.StackId),
 				name: aws.StringValue(stack.StackName),
 			}
-			if set.Mark(o, stack.CreationTime) {
-				logger.Warningf("%s: deleting %T: %s", o.ARN(), o, o.name)
-				if !opts.DryRun {
-					toDelete = append(toDelete, o)
-				}
+			tags, tagErr := cfs.fetchTags(svc, o.arn)
+			if tagErr != nil {
+				logger.Warningf("%s: failed to fetch tags: %v", o.ARN(), tagErr)
+				continue
+			}
+			if !set.Mark(opts, o, stack.CreationTime, tags) {
+				continue
+			}
+
+			logger.Warningf("%s: deleting %T: %s", o.ARN(), o, o.name)
+			if !opts.DryRun {
+				toDelete = append(toDelete, o)
 			}
 		}
 		return true

--- a/aws-janitor/resources/cloud_formation_stacks.go
+++ b/aws-janitor/resources/cloud_formation_stacks.go
@@ -30,8 +30,8 @@ import (
 // Cloud Formation Stacks
 type CloudFormationStacks struct{}
 
-func (CloudFormationStacks) fetchTags(svc *cf.CloudFormation, stackID string) ([]Tag, error) {
-	var tags []Tag
+func (CloudFormationStacks) fetchTags(svc *cf.CloudFormation, stackID string) (Tags, error) {
+	tags := make(Tags)
 	var errs []error
 
 	describeErr := svc.DescribeStacksPages(&cf.DescribeStacksInput{StackName: aws.String(stackID)},
@@ -42,7 +42,7 @@ func (CloudFormationStacks) fetchTags(svc *cf.CloudFormation, stackID string) ([
 					continue
 				}
 				for _, t := range stack.Tags {
-					tags = append(tags, NewTag(t.Key, t.Value))
+					tags.Add(t.Key, t.Value)
 				}
 			}
 			return true

--- a/aws-janitor/resources/dhcp_options.go
+++ b/aws-janitor/resources/dhcp_options.go
@@ -73,15 +73,17 @@ func (DHCPOptions) MarkAndSweep(opts Options, set *Set) error {
 		}
 
 		dh := &dhcpOption{Account: opts.Account, Region: opts.Region, ID: *dhcp.DhcpOptionsId}
-		if set.Mark(dh, nil) {
-			logger.Warningf("%s: deleting %T: %s", dh.ARN(), dhcp, dh.ID)
-			if opts.DryRun {
-				continue
-			}
+		if !set.Mark(opts, dh, nil, fromEC2Tags(dhcp.Tags)) {
+			continue
+		}
 
-			if _, err := svc.DeleteDhcpOptions(&ec2.DeleteDhcpOptionsInput{DhcpOptionsId: dhcp.DhcpOptionsId}); err != nil {
-				logger.Warningf("%s: delete failed: %v", dh.ARN(), err)
-			}
+		logger.Warningf("%s: deleting %T: %s", dh.ARN(), dhcp, dh.ID)
+		if opts.DryRun {
+			continue
+		}
+
+		if _, err := svc.DeleteDhcpOptions(&ec2.DeleteDhcpOptionsInput{DhcpOptionsId: dhcp.DhcpOptionsId}); err != nil {
+			logger.Warningf("%s: delete failed: %v", dh.ARN(), err)
 		}
 	}
 

--- a/aws-janitor/resources/dhcp_options.go
+++ b/aws-janitor/resources/dhcp_options.go
@@ -73,11 +73,12 @@ func (DHCPOptions) MarkAndSweep(opts Options, set *Set) error {
 		}
 
 		dh := &dhcpOption{Account: opts.Account, Region: opts.Region, ID: *dhcp.DhcpOptionsId}
-		if !set.Mark(opts, dh, nil, fromEC2Tags(dhcp.Tags)) {
+		tags := fromEC2Tags(dhcp.Tags)
+		if !set.Mark(opts, dh, nil, tags) {
 			continue
 		}
 
-		logger.Warningf("%s: deleting %T: %s", dh.ARN(), dhcp, dh.ID)
+		logger.Warningf("%s: deleting %T: %s (%s)", dh.ARN(), dhcp, dh.ID, tags[NameTagKey])
 		if opts.DryRun {
 			continue
 		}

--- a/aws-janitor/resources/efs.go
+++ b/aws-janitor/resources/efs.go
@@ -52,9 +52,9 @@ func (ElasticFileSystems) MarkAndSweep(opts Options, set *Set) error {
 				id:  aws.StringValue(fs.FileSystemId),
 				arn: aws.StringValue(fs.FileSystemArn),
 			}
-			tags := make([]Tag, len(fs.Tags))
+			tags := make(Tags, len(fs.Tags))
 			for _, t := range fs.Tags {
-				tags = append(tags, NewTag(t.Key, t.Value))
+				tags.Add(t.Key, t.Value)
 			}
 			if !set.Mark(opts, f, fs.CreationTime, tags) {
 				continue

--- a/aws-janitor/resources/efs.go
+++ b/aws-janitor/resources/efs.go
@@ -60,7 +60,7 @@ func (ElasticFileSystems) MarkAndSweep(opts Options, set *Set) error {
 				continue
 			}
 
-			logger.Warningf("%s: deleting %T: %s", f.ARN(), fs, *fs.Name)
+			logger.Warningf("%s: deleting %T: %s (%s)", f.ARN(), fs, aws.StringValue(fs.FileSystemId), aws.StringValue(fs.Name))
 			if !opts.DryRun {
 				fileSystemsToDelete = append(fileSystemsToDelete, f)
 			}

--- a/aws-janitor/resources/eks.go
+++ b/aws-janitor/resources/eks.go
@@ -79,9 +79,14 @@ func (EKS) describeClusters(opts Options, set *Set, svc *eks.EKS, deleteFunc fun
 					arn:  aws.StringValue(out.Cluster.Arn),
 					name: aws.StringValue(clusterName),
 				}
-				if set.Mark(cluster, out.Cluster.CreatedAt) {
-					deleteFunc(&cluster)
+				tags := make([]Tag, len(out.Cluster.Tags))
+				for k, v := range out.Cluster.Tags {
+					tags = append(tags, NewTag(aws.String(k), v))
 				}
+				if !set.Mark(opts, cluster, out.Cluster.CreatedAt, tags) {
+					continue
+				}
+				deleteFunc(&cluster)
 			}
 
 			return true

--- a/aws-janitor/resources/eks.go
+++ b/aws-janitor/resources/eks.go
@@ -79,9 +79,9 @@ func (EKS) describeClusters(opts Options, set *Set, svc *eks.EKS, deleteFunc fun
 					arn:  aws.StringValue(out.Cluster.Arn),
 					name: aws.StringValue(clusterName),
 				}
-				tags := make([]Tag, len(out.Cluster.Tags))
+				tags := make(Tags, len(out.Cluster.Tags))
 				for k, v := range out.Cluster.Tags {
-					tags = append(tags, NewTag(aws.String(k), v))
+					tags.Add(aws.String(k), v)
 				}
 				if !set.Mark(opts, cluster, out.Cluster.CreatedAt, tags) {
 					continue

--- a/aws-janitor/resources/elb.go
+++ b/aws-janitor/resources/elb.go
@@ -36,7 +36,7 @@ func (ClassicLoadBalancers) MarkAndSweep(opts Options, set *Set) error {
 	svc := elb.New(opts.Session, aws.NewConfig().WithRegion(opts.Region))
 
 	var loadBalancers []*classicLoadBalancer
-	lbTags := make(map[string][]Tag)
+	lbTags := make(map[string]Tags)
 
 	pageFunc := func(page *elb.DescribeLoadBalancersOutput, _ bool) bool {
 		for _, lb := range page.LoadBalancerDescriptions {
@@ -70,8 +70,11 @@ func (ClassicLoadBalancers) MarkAndSweep(opts Options, set *Set) error {
 				errs = append(errs, fmt.Errorf("unknown load balancer in tag response: %s", lbName))
 				continue
 			}
+			if lbTags[lbName] == nil {
+				lbTags[lbName] = make(Tags, len(tagDesc.Tags))
+			}
 			for _, t := range tagDesc.Tags {
-				lbTags[lbName] = append(lbTags[lbName], NewTag(t.Key, t.Value))
+				lbTags[lbName].Add(t.Key, t.Value)
 			}
 		}
 		return kerrors.NewAggregate(errs)

--- a/aws-janitor/resources/elbv2.go
+++ b/aws-janitor/resources/elbv2.go
@@ -17,12 +17,14 @@ limitations under the License.
 package resources
 
 import (
+	"fmt"
 	"time"
 
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/service/elbv2"
 	"github.com/pkg/errors"
 	"github.com/sirupsen/logrus"
+	kerrors "k8s.io/apimachinery/pkg/util/errors"
 )
 
 // Clean-up ELBs
@@ -33,17 +35,18 @@ func (LoadBalancers) MarkAndSweep(opts Options, set *Set) error {
 	logger := logrus.WithField("options", opts)
 	svc := elbv2.New(opts.Session, aws.NewConfig().WithRegion(opts.Region))
 
-	var toDelete []*loadBalancer // Paged call, defer deletion until we have the whole list.
+	var loadBalancers []*loadBalancer
+	lbTags := make(map[string][]Tag)
 
 	pageFunc := func(page *elbv2.DescribeLoadBalancersOutput, _ bool) bool {
 		for _, lb := range page.LoadBalancers {
-			a := &loadBalancer{arn: *lb.LoadBalancerArn}
-			if set.Mark(a, lb.CreatedTime) {
-				logger.Warningf("%s: deleting %T: %s", a.ARN(), lb, *lb.LoadBalancerName)
-				if !opts.DryRun {
-					toDelete = append(toDelete, a)
-				}
+			a := &loadBalancer{
+				arn:         aws.StringValue(lb.LoadBalancerArn),
+				name:        aws.StringValue(lb.LoadBalancerName),
+				createdTime: lb.CreatedTime,
 			}
+			loadBalancers = append(loadBalancers, a)
+			lbTags[a.ARN()] = nil
 		}
 		return true
 	}
@@ -52,7 +55,41 @@ func (LoadBalancers) MarkAndSweep(opts Options, set *Set) error {
 		return err
 	}
 
-	for _, lb := range toDelete {
+	fetchTagErr := incrementalFetchTags(lbTags, 20, func(lbArns []*string) error {
+		tagsResp, err := svc.DescribeTags(&elbv2.DescribeTagsInput{ResourceArns: lbArns})
+		if err != nil {
+			return err
+		}
+
+		var errs []error
+		for _, tagDesc := range tagsResp.TagDescriptions {
+			arn := aws.StringValue(tagDesc.ResourceArn)
+			_, ok := lbTags[arn]
+			if !ok {
+				errs = append(errs, fmt.Errorf("unknown load balancer ARN in tag response: %s", arn))
+				continue
+			}
+			for _, t := range tagDesc.Tags {
+				lbTags[arn] = append(lbTags[arn], NewTag(t.Key, t.Value))
+			}
+		}
+		return kerrors.NewAggregate(errs)
+	})
+
+	if fetchTagErr != nil {
+		return fetchTagErr
+	}
+
+	for _, lb := range loadBalancers {
+		if !set.Mark(opts, lb, lb.createdTime, lbTags[lb.ARN()]) {
+			continue
+		}
+		logger.Warningf("%s: deleting %T: %s", lb.ARN(), lb, lb.name)
+
+		if opts.DryRun {
+			continue
+		}
+
 		deleteInput := &elbv2.DeleteLoadBalancerInput{
 			LoadBalancerArn: aws.String(lb.ARN()),
 		}
@@ -73,7 +110,7 @@ func (LoadBalancers) ListAll(opts Options) (*Set, error) {
 	err := c.DescribeLoadBalancersPages(input, func(lbs *elbv2.DescribeLoadBalancersOutput, isLast bool) bool {
 		now := time.Now()
 		for _, lb := range lbs.LoadBalancers {
-			a := &loadBalancer{arn: *lb.LoadBalancerArn}
+			a := &loadBalancer{arn: *lb.LoadBalancerArn, name: *lb.LoadBalancerName}
 			set.firstSeen[a.ResourceKey()] = now
 		}
 
@@ -84,7 +121,9 @@ func (LoadBalancers) ListAll(opts Options) (*Set, error) {
 }
 
 type loadBalancer struct {
-	arn string
+	arn         string
+	name        string
+	createdTime *time.Time
 }
 
 func (lb loadBalancer) ARN() string {

--- a/aws-janitor/resources/elbv2.go
+++ b/aws-janitor/resources/elbv2.go
@@ -36,7 +36,7 @@ func (LoadBalancers) MarkAndSweep(opts Options, set *Set) error {
 	svc := elbv2.New(opts.Session, aws.NewConfig().WithRegion(opts.Region))
 
 	var loadBalancers []*loadBalancer
-	lbTags := make(map[string][]Tag)
+	lbTags := make(map[string]Tags)
 
 	pageFunc := func(page *elbv2.DescribeLoadBalancersOutput, _ bool) bool {
 		for _, lb := range page.LoadBalancers {
@@ -69,8 +69,11 @@ func (LoadBalancers) MarkAndSweep(opts Options, set *Set) error {
 				errs = append(errs, fmt.Errorf("unknown load balancer ARN in tag response: %s", arn))
 				continue
 			}
+			if lbTags[arn] == nil {
+				lbTags[arn] = make(Tags, len(tagDesc.Tags))
+			}
 			for _, t := range tagDesc.Tags {
-				lbTags[arn] = append(lbTags[arn], NewTag(t.Key, t.Value))
+				lbTags[arn].Add(t.Key, t.Value)
 			}
 		}
 		return kerrors.NewAggregate(errs)

--- a/aws-janitor/resources/iam_roles.go
+++ b/aws-janitor/resources/iam_roles.go
@@ -31,8 +31,8 @@ import (
 
 type IAMRoles struct{}
 
-func roleTags(svc *iam.IAM, role *iam.Role) ([]Tag, error) {
-	var tags []Tag
+func roleTags(svc *iam.IAM, role *iam.Role) (Tags, error) {
+	tags := make(Tags)
 	roleTagsInput := &iam.ListRoleTagsInput{RoleName: role.RoleName}
 	for {
 		tagsResp, err := svc.ListRoleTags(roleTagsInput)
@@ -40,7 +40,7 @@ func roleTags(svc *iam.IAM, role *iam.Role) ([]Tag, error) {
 			return nil, fmt.Errorf("role %s: failed querying for tags: %v", aws.StringValue(role.RoleName), err)
 		}
 		for _, t := range tagsResp.Tags {
-			tags = append(tags, NewTag(t.Key, t.Value))
+			tags.Add(t.Key, t.Value)
 		}
 		if !aws.BoolValue(tagsResp.IsTruncated) {
 			break

--- a/aws-janitor/resources/instance.go
+++ b/aws-janitor/resources/instance.go
@@ -55,11 +55,13 @@ func (Instances) MarkAndSweep(opts Options, set *Set) error {
 					InstanceID: *inst.InstanceId,
 				}
 				// Instances don't have a creation date, but launch time is better than nothing.
-				if set.Mark(i, inst.LaunchTime) {
-					logger.Warningf("%s: deleting %T: %s", i.ARN(), inst, i.InstanceID)
-					if !opts.DryRun {
-						toDelete = append(toDelete, inst.InstanceId)
-					}
+				if !set.Mark(opts, i, inst.LaunchTime, fromEC2Tags(inst.Tags)) {
+					continue
+				}
+
+				logger.Warningf("%s: deleting %T: %s", i.ARN(), inst, i.InstanceID)
+				if !opts.DryRun {
+					toDelete = append(toDelete, inst.InstanceId)
 				}
 			}
 		}

--- a/aws-janitor/resources/instance.go
+++ b/aws-janitor/resources/instance.go
@@ -54,12 +54,13 @@ func (Instances) MarkAndSweep(opts Options, set *Set) error {
 					Region:     opts.Region,
 					InstanceID: *inst.InstanceId,
 				}
+				tags := fromEC2Tags(inst.Tags)
 				// Instances don't have a creation date, but launch time is better than nothing.
-				if !set.Mark(opts, i, inst.LaunchTime, fromEC2Tags(inst.Tags)) {
+				if !set.Mark(opts, i, inst.LaunchTime, tags) {
 					continue
 				}
 
-				logger.Warningf("%s: deleting %T: %s", i.ARN(), inst, i.InstanceID)
+				logger.Warningf("%s: deleting %T: %s (%s)", i.ARN(), inst, i.InstanceID, tags[NameTagKey])
 				if !opts.DryRun {
 					toDelete = append(toDelete, inst.InstanceId)
 				}

--- a/aws-janitor/resources/internet_gateways.go
+++ b/aws-janitor/resources/internet_gateways.go
@@ -61,16 +61,15 @@ func (InternetGateways) MarkAndSweep(opts Options, set *Set) error {
 
 	for _, ig := range resp.InternetGateways {
 		i := &internetGateway{Account: opts.Account, Region: opts.Region, ID: *ig.InternetGatewayId}
-
-		if !set.Mark(i, nil) {
+		if !set.Mark(opts, i, nil, fromEC2Tags(ig.Tags)) {
 			continue
 		}
-		isDefault := false
 		logger.Warningf("%s: deleting %T: %s", i.ARN(), ig, i.ID)
 		if opts.DryRun {
 			continue
 		}
 
+		isDefault := false
 		for _, att := range ig.Attachments {
 			if defaultVPC[aws.StringValue(att.VpcId)] {
 				isDefault = true

--- a/aws-janitor/resources/internet_gateways.go
+++ b/aws-janitor/resources/internet_gateways.go
@@ -61,10 +61,11 @@ func (InternetGateways) MarkAndSweep(opts Options, set *Set) error {
 
 	for _, ig := range resp.InternetGateways {
 		i := &internetGateway{Account: opts.Account, Region: opts.Region, ID: *ig.InternetGatewayId}
-		if !set.Mark(opts, i, nil, fromEC2Tags(ig.Tags)) {
+		tags := fromEC2Tags(ig.Tags)
+		if !set.Mark(opts, i, nil, tags) {
 			continue
 		}
-		logger.Warningf("%s: deleting %T: %s", i.ARN(), ig, i.ID)
+		logger.Warningf("%s: deleting %T: %s (%s)", i.ARN(), ig, i.ID, tags[NameTagKey])
 		if opts.DryRun {
 			continue
 		}

--- a/aws-janitor/resources/launch_configs.go
+++ b/aws-janitor/resources/launch_configs.go
@@ -40,7 +40,8 @@ func (LaunchConfigurations) MarkAndSweep(opts Options, set *Set) error {
 				arn:  aws.StringValue(lc.LaunchConfigurationARN),
 				name: aws.StringValue(lc.LaunchConfigurationName),
 			}
-			if set.Mark(l, lc.CreatedTime) {
+			// No tags?
+			if set.Mark(opts, l, lc.CreatedTime, nil) {
 				logger.Warningf("%s: deleting %T: %s", l.ARN(), lc, l.name)
 				if !opts.DryRun {
 					toDelete = append(toDelete, l)

--- a/aws-janitor/resources/launch_templates.go
+++ b/aws-janitor/resources/launch_templates.go
@@ -43,11 +43,12 @@ func (LaunchTemplates) MarkAndSweep(opts Options, set *Set) error {
 				ID:      *lt.LaunchTemplateId,
 				Name:    *lt.LaunchTemplateName,
 			}
-			if set.Mark(l, lt.CreateTime) {
-				logger.Warningf("%s: deleting %T: %s", l.ARN(), lt, l.Name)
-				if !opts.DryRun {
-					toDelete = append(toDelete, l)
-				}
+			if !set.Mark(opts, l, lt.CreateTime, fromEC2Tags(lt.Tags)) {
+				continue
+			}
+			logger.Warningf("%s: deleting %T: %s", l.ARN(), lt, l.Name)
+			if !opts.DryRun {
+				toDelete = append(toDelete, l)
 			}
 		}
 		return true

--- a/aws-janitor/resources/list.go
+++ b/aws-janitor/resources/list.go
@@ -26,6 +26,13 @@ type Options struct {
 	Account string
 	Region  string
 
+	// Only resources which contain all IncludeTags will be considered for cleanup.
+	IncludeTags TagMatcher
+	// Any resources with at least one tag in ExcludeTags will be excluded from cleanup.
+	// ExcludeTags takes precedence over IncludeTags - i.e. a resource that matches both
+	// will be excluded.
+	ExcludeTags TagMatcher
+
 	// Whether to actually delete resources, or just report what would be deleted.
 	DryRun bool
 }

--- a/aws-janitor/resources/list.go
+++ b/aws-janitor/resources/list.go
@@ -33,6 +33,10 @@ type Options struct {
 	// will be excluded.
 	ExcludeTags TagMatcher
 
+	// If set, any resources with a tag matching this key can override the global TTL (unless the global TTL is 0).
+	// The value of the tag must be a valid Go time.Duration string.
+	TTLTagKey string
+
 	// Whether to actually delete resources, or just report what would be deleted.
 	DryRun bool
 }

--- a/aws-janitor/resources/nat_gateway.go
+++ b/aws-janitor/resources/nat_gateway.go
@@ -45,15 +45,16 @@ func (NATGateway) MarkAndSweep(opts Options, set *Set) error {
 				ID:      *gw.NatGatewayId,
 			}
 
-			if set.Mark(g, gw.CreateTime) {
-				logger.Warningf("%s: deleting %T: %s", g.ARN(), gw, g.ID)
-				if opts.DryRun {
-					continue
-				}
-				inp := &ec2.DeleteNatGatewayInput{NatGatewayId: gw.NatGatewayId}
-				if _, err := svc.DeleteNatGateway(inp); err != nil {
-					logger.Warningf("%s: delete failed: %v", g.ARN(), err)
-				}
+			if !set.Mark(opts, g, gw.CreateTime, fromEC2Tags(gw.Tags)) {
+				continue
+			}
+			logger.Warningf("%s: deleting %T: %s", g.ARN(), gw, g.ID)
+			if opts.DryRun {
+				continue
+			}
+			inp := &ec2.DeleteNatGatewayInput{NatGatewayId: gw.NatGatewayId}
+			if _, err := svc.DeleteNatGateway(inp); err != nil {
+				logger.Warningf("%s: delete failed: %v", g.ARN(), err)
 			}
 		}
 		return true

--- a/aws-janitor/resources/nat_gateway.go
+++ b/aws-janitor/resources/nat_gateway.go
@@ -45,10 +45,11 @@ func (NATGateway) MarkAndSweep(opts Options, set *Set) error {
 				ID:      *gw.NatGatewayId,
 			}
 
-			if !set.Mark(opts, g, gw.CreateTime, fromEC2Tags(gw.Tags)) {
+			tags := fromEC2Tags(gw.Tags)
+			if !set.Mark(opts, g, gw.CreateTime, tags) {
 				continue
 			}
-			logger.Warningf("%s: deleting %T: %s", g.ARN(), gw, g.ID)
+			logger.Warningf("%s: deleting %T: %s (%s)", g.ARN(), gw, g.ID, tags[NameTagKey])
 			if opts.DryRun {
 				continue
 			}

--- a/aws-janitor/resources/network_interface.go
+++ b/aws-janitor/resources/network_interface.go
@@ -44,8 +44,9 @@ func (NetworkInterfaces) MarkAndSweep(opts Options, set *Set) error {
 				a.AttachmentID = *eni.Attachment.AttachmentId
 				attachTime = eni.Attachment.AttachTime
 			}
+			tags := fromEC2Tags(eni.TagSet)
 			// AttachTime isn't exactly the creation time, but it's better than nothing.
-			if !set.Mark(opts, a, attachTime, fromEC2Tags(eni.TagSet)) {
+			if !set.Mark(opts, a, attachTime, tags) {
 				continue
 			}
 			// Since tags and other metadata may not propagate to ENIs from their attachments,
@@ -54,7 +55,7 @@ func (NetworkInterfaces) MarkAndSweep(opts Options, set *Set) error {
 			if eni.Attachment != nil {
 				continue
 			}
-			logger.Warningf("%s: deleting %T", a.ARN(), a)
+			logger.Warningf("%s: deleting %T (%s)", a.ARN(), a, tags[NameTagKey])
 			if !opts.DryRun {
 				toDelete = append(toDelete, a)
 			}

--- a/aws-janitor/resources/network_interface.go
+++ b/aws-janitor/resources/network_interface.go
@@ -45,11 +45,18 @@ func (NetworkInterfaces) MarkAndSweep(opts Options, set *Set) error {
 				attachTime = eni.Attachment.AttachTime
 			}
 			// AttachTime isn't exactly the creation time, but it's better than nothing.
-			if set.Mark(a, attachTime) {
-				logger.Warningf("%s: deleting %T", a.ARN(), a)
-				if !opts.DryRun {
-					toDelete = append(toDelete, a)
-				}
+			if !set.Mark(opts, a, attachTime, fromEC2Tags(eni.TagSet)) {
+				continue
+			}
+			// Since tags and other metadata may not propagate to ENIs from their attachments,
+			// we avoid deleting any ENI that is currently attached. Once their attached resource is deleted,
+			// we can safely delete ENIs in a later clean-up run (using the mark data we saved in this run).
+			if eni.Attachment != nil {
+				continue
+			}
+			logger.Warningf("%s: deleting %T", a.ARN(), a)
+			if !opts.DryRun {
+				toDelete = append(toDelete, a)
 			}
 		}
 		return true
@@ -60,15 +67,6 @@ func (NetworkInterfaces) MarkAndSweep(opts Options, set *Set) error {
 	}
 
 	for _, eni := range toDelete {
-		if eni.AttachmentID != "" {
-			detachInput := &ec2.DetachNetworkInterfaceInput{
-				AttachmentId: aws.String(eni.AttachmentID),
-			}
-			if _, err := svc.DetachNetworkInterface(detachInput); err != nil {
-				logger.Warningf("%s: detach failed: %v", eni.ARN(), err)
-			}
-		}
-
 		deleteInput := &ec2.DeleteNetworkInterfaceInput{
 			NetworkInterfaceId: aws.String(eni.ID),
 		}

--- a/aws-janitor/resources/route_tables.go
+++ b/aws-janitor/resources/route_tables.go
@@ -54,10 +54,11 @@ func (RouteTables) MarkAndSweep(opts Options, set *Set) error {
 		}
 
 		r := &routeTable{Account: opts.Account, Region: opts.Region, ID: *rt.RouteTableId}
-		if !set.Mark(opts, r, nil, fromEC2Tags(rt.Tags)) {
+		tags := fromEC2Tags(rt.Tags)
+		if !set.Mark(opts, r, nil, tags) {
 			continue
 		}
-		logger.Warningf("%s: deleting %T: %s", r.ARN(), rt, r.ID)
+		logger.Warningf("%s: deleting %T: %s (%s)", r.ARN(), rt, r.ID, tags[NameTagKey])
 		if opts.DryRun {
 			continue
 		}

--- a/aws-janitor/resources/security_groups.go
+++ b/aws-janitor/resources/security_groups.go
@@ -66,11 +66,12 @@ func (SecurityGroups) MarkAndSweep(opts Options, set *Set) error {
 		s := &securityGroup{Account: opts.Account, Region: opts.Region, ID: *sg.GroupId}
 		addRefs(ingress, *sg.GroupId, opts.Account, sg.IpPermissions)
 		addRefs(egress, *sg.GroupId, opts.Account, sg.IpPermissionsEgress)
-		if set.Mark(s, nil) {
-			logger.Warningf("%s: deleting %T: %s", s.ARN(), sg, s.ID)
-			if !opts.DryRun {
-				toDelete = append(toDelete, s)
-			}
+		if !set.Mark(opts, s, nil, fromEC2Tags(sg.Tags)) {
+			continue
+		}
+		logger.Warningf("%s: deleting %T: %s", s.ARN(), sg, s.ID)
+		if !opts.DryRun {
+			toDelete = append(toDelete, s)
 		}
 	}
 

--- a/aws-janitor/resources/security_groups.go
+++ b/aws-janitor/resources/security_groups.go
@@ -69,7 +69,7 @@ func (SecurityGroups) MarkAndSweep(opts Options, set *Set) error {
 		if !set.Mark(opts, s, nil, fromEC2Tags(sg.Tags)) {
 			continue
 		}
-		logger.Warningf("%s: deleting %T: %s", s.ARN(), sg, s.ID)
+		logger.Warningf("%s: deleting %T: %s (%s)", s.ARN(), sg, s.ID, aws.StringValue(sg.GroupName))
 		if !opts.DryRun {
 			toDelete = append(toDelete, s)
 		}

--- a/aws-janitor/resources/set.go
+++ b/aws-janitor/resources/set.go
@@ -105,6 +105,10 @@ func (s *Set) Save(sess *session.Session, p *s3path.Path) error {
 // When determining whether a resource should be deleted, first the options for
 // IncludeTags and ExcludeTags are applied against the provided tags.
 // If the resource should be managed per tags, then the TTL is evaluated.
+// Note that if the TTLTagKey option is set, the resource has a tag matching this key,
+// and the global TTL is not set to 0, then the TTL duration in this tag's value will
+// be used for this resource.
+//
 // If Mark(r) returns true, the resource is managed per tags, and the TTL has expired
 // for r and it should be deleted.
 // If the created time is not provided, the current time is used instead.
@@ -131,8 +135,24 @@ func (s *Set) Mark(opts Options, r Interface, created *time.Time, tags []Tag) bo
 		return false
 	}
 
-	// If the TTL is 0, it should be deleted now.
-	if s.ttl == 0 || now.Sub(firstSeen) > s.ttl {
+	perResourceTTL := s.ttl
+	if opts.TTLTagKey != "" {
+		for _, tag := range tags {
+			if tag.Key == opts.TTLTagKey {
+				tagTTL, err := time.ParseDuration(tag.Value)
+				if err != nil {
+					logrus.Errorf("resource %s: invalid duration '%s' in tag '%s': %v", r.ResourceKey(), tag.Value, tag.Key, err)
+				} else {
+					perResourceTTL = tagTTL
+					logrus.Debugf("resource %s: TTL set to %v by tag", r.ResourceKey(), perResourceTTL)
+				}
+				break
+			}
+		}
+	}
+
+	// If the global TTL is 0, the resource should be deleted now. (This cannot be overridden by tags.)
+	if s.ttl == 0 || now.Sub(firstSeen) > perResourceTTL {
 		s.swept = append(s.swept, key)
 		return true
 	}

--- a/aws-janitor/resources/set.go
+++ b/aws-janitor/resources/set.go
@@ -101,9 +101,14 @@ func (s *Set) Save(sess *session.Session, p *s3path.Path) error {
 
 // Mark marks a particular resource as currently present, records when it was
 // created or first seen, and advises on whether it should be deleted.
-// If Mark(r) returns true, the TTL has expired for r and it should be deleted.
+//
+// When determining whether a resource should be deleted, first the options for
+// IncludeTags and ExcludeTags are applied against the provided tags.
+// If the resource should be managed per tags, then the TTL is evaluated.
+// If Mark(r) returns true, the resource is managed per tags, and the TTL has expired
+// for r and it should be deleted.
 // If the created time is not provided, the current time is used instead.
-func (s *Set) Mark(r Interface, created *time.Time) bool {
+func (s *Set) Mark(opts Options, r Interface, created *time.Time, tags []Tag) bool {
 	key := r.ResourceKey()
 	s.marked[key] = true
 
@@ -121,6 +126,10 @@ func (s *Set) Mark(r Interface, created *time.Time) bool {
 		firstSeen = t
 	}
 	s.firstSeen[key] = firstSeen
+
+	if !opts.ManagedPerTags(tags) {
+		return false
+	}
 
 	// If the TTL is 0, it should be deleted now.
 	if s.ttl == 0 || now.Sub(firstSeen) > s.ttl {

--- a/aws-janitor/resources/set_test.go
+++ b/aws-janitor/resources/set_test.go
@@ -70,6 +70,7 @@ func TestMarkCreationTimes(t *testing.T) {
 			ShouldDelete      bool
 			CreateTime        *time.Time
 			ExpectedFirstSeen time.Time
+			Tags              []Tag
 		}{
 			{
 				// New resource, no creation time -> should use time.Now()
@@ -124,7 +125,8 @@ func TestMarkCreationTimes(t *testing.T) {
 			},
 		} {
 			shouldDelete := deleteAll || tc.ShouldDelete
-			delete := s.Mark(tc.Resource, tc.CreateTime)
+			opts := Options{}
+			delete := s.Mark(opts, tc.Resource, tc.CreateTime, tc.Tags)
 			if delete != shouldDelete {
 				t.Errorf("%s: delete: expected=%v, got=%v", tc.Resource.Name, shouldDelete, delete)
 			}

--- a/aws-janitor/resources/set_test.go
+++ b/aws-janitor/resources/set_test.go
@@ -77,7 +77,7 @@ func TestMarkCreationTimes(t *testing.T) {
 			ShouldDelete      bool
 			CreateTime        *time.Time
 			ExpectedFirstSeen time.Time
-			Tags              []Tag
+			Tags              Tags
 			Unmanaged         bool
 		}{
 			{
@@ -136,7 +136,7 @@ func TestMarkCreationTimes(t *testing.T) {
 				ShouldDelete:      false,
 				CreateTime:        &sixHoursAgo,
 				ExpectedFirstSeen: sixHoursAgo,
-				Tags:              []Tag{{janitorExcludeKey, "true"}},
+				Tags:              Tags{janitorExcludeKey: "true"},
 				Unmanaged:         true,
 			},
 			{
@@ -144,14 +144,14 @@ func TestMarkCreationTimes(t *testing.T) {
 				ShouldDelete:      true,
 				CreateTime:        &sixHoursAgo,
 				ExpectedFirstSeen: sixHoursAgo,
-				Tags:              []Tag{{janitorTTLKey, "foo"}},
+				Tags:              Tags{janitorTTLKey: "foo"},
 			},
 			{
 				Resource:          fakeResource{"OverrideDurationTag"},
 				ShouldDelete:      false,
 				CreateTime:        &sixHoursAgo,
 				ExpectedFirstSeen: sixHoursAgo,
-				Tags:              []Tag{{janitorTTLKey, "12h"}},
+				Tags:              Tags{janitorTTLKey: "12h"},
 			},
 		} {
 			shouldDelete := (deleteAll || tc.ShouldDelete) && !tc.Unmanaged

--- a/aws-janitor/resources/snapshots.go
+++ b/aws-janitor/resources/snapshots.go
@@ -49,11 +49,12 @@ func (Snapshots) MarkAndSweep(opts Options, set *Set) error {
 				ID:      aws.StringValue(ss.SnapshotId),
 			}
 			// StartTime is probably close enough to a creation timestamp
-			if set.Mark(s, ss.StartTime) {
-				logger.Warningf("%s: deleting %T", s.ARN(), s)
-				if !opts.DryRun {
-					toDelete = append(toDelete, s)
-				}
+			if !set.Mark(opts, s, ss.StartTime, fromEC2Tags(ss.Tags)) {
+				continue
+			}
+			logger.Warningf("%s: deleting %T", s.ARN(), s)
+			if !opts.DryRun {
+				toDelete = append(toDelete, s)
 			}
 		}
 		return true

--- a/aws-janitor/resources/snapshots.go
+++ b/aws-janitor/resources/snapshots.go
@@ -48,11 +48,12 @@ func (Snapshots) MarkAndSweep(opts Options, set *Set) error {
 				Region:  opts.Region,
 				ID:      aws.StringValue(ss.SnapshotId),
 			}
+			tags := fromEC2Tags(ss.Tags)
 			// StartTime is probably close enough to a creation timestamp
-			if !set.Mark(opts, s, ss.StartTime, fromEC2Tags(ss.Tags)) {
+			if !set.Mark(opts, s, ss.StartTime, tags) {
 				continue
 			}
-			logger.Warningf("%s: deleting %T", s.ARN(), s)
+			logger.Warningf("%s: deleting %T (%s)", s.ARN(), s, tags[NameTagKey])
 			if !opts.DryRun {
 				toDelete = append(toDelete, s)
 			}

--- a/aws-janitor/resources/sqs.go
+++ b/aws-janitor/resources/sqs.go
@@ -66,9 +66,9 @@ func (SQSQueues) MarkAndSweep(opts Options, set *Set) error {
 				logger.Warningf("%s: failed listing tags: %v", q.ARN(), err)
 				return false
 			}
-			tags := make([]Tag, len(tagResp.Tags))
+			tags := make(Tags, len(tagResp.Tags))
 			for k, v := range tagResp.Tags {
-				tags = append(tags, NewTag(aws.String(k), v))
+				tags.Add(aws.String(k), v)
 			}
 			if !set.Mark(opts, q, &creationTime, tags) {
 				continue

--- a/aws-janitor/resources/subnets.go
+++ b/aws-janitor/resources/subnets.go
@@ -49,14 +49,16 @@ func (Subnets) MarkAndSweep(opts Options, set *Set) error {
 
 	for _, sub := range resp.Subnets {
 		s := &subnet{Account: opts.Account, Region: opts.Region, ID: *sub.SubnetId}
-		if set.Mark(s, nil) {
-			logger.Warningf("%s: deleting %T: %s", s.ARN(), sub, s.ID)
-			if opts.DryRun {
-				continue
-			}
-			if _, err := svc.DeleteSubnet(&ec2.DeleteSubnetInput{SubnetId: sub.SubnetId}); err != nil {
-				logger.Warningf("%s: delete failed: %v", s.ARN(), err)
-			}
+		if !set.Mark(opts, s, nil, fromEC2Tags(sub.Tags)) {
+			continue
+		}
+
+		logger.Warningf("%s: deleting %T: %s", s.ARN(), sub, s.ID)
+		if opts.DryRun {
+			continue
+		}
+		if _, err := svc.DeleteSubnet(&ec2.DeleteSubnetInput{SubnetId: sub.SubnetId}); err != nil {
+			logger.Warningf("%s: delete failed: %v", s.ARN(), err)
 		}
 	}
 

--- a/aws-janitor/resources/subnets.go
+++ b/aws-janitor/resources/subnets.go
@@ -49,11 +49,12 @@ func (Subnets) MarkAndSweep(opts Options, set *Set) error {
 
 	for _, sub := range resp.Subnets {
 		s := &subnet{Account: opts.Account, Region: opts.Region, ID: *sub.SubnetId}
-		if !set.Mark(opts, s, nil, fromEC2Tags(sub.Tags)) {
+		tags := fromEC2Tags(sub.Tags)
+		if !set.Mark(opts, s, nil, tags) {
 			continue
 		}
 
-		logger.Warningf("%s: deleting %T: %s", s.ARN(), sub, s.ID)
+		logger.Warningf("%s: deleting %T: %s (%s)", s.ARN(), sub, s.ID, tags[NameTagKey])
 		if opts.DryRun {
 			continue
 		}

--- a/aws-janitor/resources/tags.go
+++ b/aws-janitor/resources/tags.go
@@ -1,0 +1,121 @@
+/*
+Copyright 2021 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package resources
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/service/ec2"
+	"k8s.io/apimachinery/pkg/util/sets"
+)
+
+type Tag struct {
+	Key   string
+	Value string
+}
+
+func NewTag(key *string, value *string) Tag {
+	return Tag{
+		Key:   aws.StringValue(key),
+		Value: aws.StringValue(value),
+	}
+}
+
+// TagMatcher maps keys to valid values. An empty set of values will result in matching tags with any value.
+type TagMatcher map[string]sets.String
+
+// TagMatcherForTags creates a new TagMatcher for the given list of tags provided in key=value format.
+// If "=value" is not provided, then the TagMatcher will match any value for that key.
+// (If the value is empty, only an empty tag value matches.)
+func TagMatcherForTags(tags []string) (TagMatcher, error) {
+	tm := make(TagMatcher)
+	for _, tag := range tags {
+		parts := strings.SplitN(tag, "=", 2)
+		if len(parts) < 1 {
+			return nil, fmt.Errorf("invalid tag: %q", tag)
+		}
+		key := parts[0]
+		if _, ok := tm[key]; !ok {
+			tm[key] = sets.NewString()
+		}
+		if len(parts) == 2 {
+			tm[key].Insert(parts[1])
+		}
+	}
+
+	return tm, nil
+}
+
+func (tm TagMatcher) Matches(tag Tag) bool {
+	vals, ok := tm[tag.Key]
+	if !ok {
+		// No tag matcher for this key
+		return false
+	}
+	if vals.Len() == 0 {
+		// This matcher matches all values for a given key.
+		return true
+	}
+	return vals.Has(tag.Value)
+}
+
+// ManagedPerTags returns whether the given list of tags is matched by all IncludeTags and no ExcludeTags.
+func (opts Options) ManagedPerTags(tags []Tag) bool {
+	included := 0
+	for _, t := range tags {
+		if opts.ExcludeTags.Matches(t) {
+			return false
+		}
+		if opts.IncludeTags.Matches(t) {
+			included++
+		}
+	}
+	return included == len(opts.IncludeTags)
+}
+
+func fromEC2Tags(ec2tags []*ec2.Tag) []Tag {
+	tags := make([]Tag, 0, len(ec2tags))
+	for _, ec2t := range ec2tags {
+		tags = append(tags, NewTag(ec2t.Key, ec2t.Value))
+	}
+	return tags
+}
+
+// incrementalFetchTags creates slices of IDs from tagMap no longer than inc at a time, calling
+// f with these slices.
+// This is intended to be used with APIs that allow querying for tags of a limited number of multiple resources at once.
+// If f errors, incrementalFetchTags returns early with the error.
+func incrementalFetchTags(tagMap map[string][]Tag, inc int, f func([]*string) error) error {
+	ids := make([]*string, 0, len(tagMap))
+	for id := range tagMap {
+		ids = append(ids, aws.String(id))
+	}
+
+	for start := 0; start < len(ids); start += inc {
+		end := start + inc
+		if end > len(ids) {
+			end = len(ids)
+		}
+		err := f(ids[start:end])
+		if err != nil {
+			return err
+		}
+	}
+	return nil
+}

--- a/aws-janitor/resources/tags.go
+++ b/aws-janitor/resources/tags.go
@@ -25,6 +25,10 @@ import (
 	"k8s.io/apimachinery/pkg/util/sets"
 )
 
+const (
+	NameTagKey = "Name"
+)
+
 type Tags map[string]string
 
 func (tags Tags) Add(key *string, value *string) {

--- a/aws-janitor/resources/tags_test.go
+++ b/aws-janitor/resources/tags_test.go
@@ -1,0 +1,234 @@
+/*
+Copyright 2021 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package resources
+
+import (
+	"testing"
+
+	"github.com/aws/aws-sdk-go/aws"
+)
+
+func TestMatchesTag(t *testing.T) {
+	tm, err := TagMatcherForTags([]string{
+		"onlyKey",
+		"keyWithEquals=",
+		"foo=1",
+		"foo=2",
+		"bar=abc",
+	})
+	if err != nil {
+		t.Fatalf("unexpected error creating tag matcher: %v", err)
+	}
+	for _, tc := range []struct {
+		Tag         Tag
+		ShouldMatch bool
+	}{
+		{
+			Tag:         Tag{"onlyKey", "some value"},
+			ShouldMatch: true,
+		},
+		{
+			Tag:         Tag{"onlyKey", ""},
+			ShouldMatch: true,
+		},
+		{
+			Tag:         Tag{"keyWithEquals=", "val"},
+			ShouldMatch: false,
+		},
+		{
+			Tag:         Tag{"keyWithEquals=", ""},
+			ShouldMatch: false,
+		},
+		{
+			Tag:         Tag{"keyWithEquals", "val"},
+			ShouldMatch: false,
+		},
+		{
+			Tag:         Tag{"keyWithEquals", ""},
+			ShouldMatch: true,
+		},
+		{
+			Tag:         Tag{"foo", "1"},
+			ShouldMatch: true,
+		},
+		{
+			Tag:         Tag{"foo", "2"},
+			ShouldMatch: true,
+		},
+		{
+			Tag:         Tag{"foo", "3"},
+			ShouldMatch: false,
+		},
+		{
+			Tag:         Tag{"bar", "abc"},
+			ShouldMatch: true,
+		},
+		{
+			Tag:         Tag{"bar", ""},
+			ShouldMatch: false,
+		},
+		{
+			Tag:         Tag{"bar", "xyz"},
+			ShouldMatch: false,
+		},
+	} {
+		matches := tm.Matches(tc.Tag)
+		if matches != tc.ShouldMatch {
+			t.Errorf("Tag %+v: matches: expected=%v, got=%v", tc.Tag, tc.ShouldMatch, matches)
+		}
+	}
+}
+
+func TestManagedPerTags(t *testing.T) {
+	// These tags and matchers aren't using values, since we test that in the other unit test.
+	metasynTags := []Tag{{"foo", ""}, {"bar", ""}, {"baz", ""}}
+	tmBar, err := TagMatcherForTags([]string{"bar"})
+	if err != nil {
+		t.Fatalf("unexpected error creating tag matcher: %v", err)
+	}
+	colorTags := []Tag{{"red", ""}, {"orange", ""}, {"yellow", ""}, {"green", ""}, {"blue", ""}, {"indigo", ""}, {"violet", ""}}
+	tmRGB, err := TagMatcherForTags([]string{"red", "green", "blue"})
+	if err != nil {
+		t.Fatalf("unexpected error creating tag matcher: %v", err)
+	}
+	tmEmpty, err := TagMatcherForTags(nil)
+	if err != nil {
+		t.Fatalf("unexpected error creating tag matcher: %v", err)
+	}
+
+	for _, tc := range []struct {
+		Desc         string
+		Tags         []Tag
+		IncludeTags  TagMatcher
+		ExcludeTags  TagMatcher
+		ShouldManage bool
+	}{
+		{
+			Desc:         "no tags, no matchers",
+			IncludeTags:  tmEmpty,
+			ExcludeTags:  tmEmpty,
+			ShouldManage: true,
+		},
+		{
+			Desc:         "no tags, empty include, set exclude",
+			IncludeTags:  tmEmpty,
+			ExcludeTags:  tmBar,
+			ShouldManage: true,
+		},
+		{
+			Desc:         "no tags, set include, empty exclude tags",
+			IncludeTags:  tmRGB,
+			ExcludeTags:  tmEmpty,
+			ShouldManage: false,
+		},
+		{
+			Desc:         "exclude by tag (no include)",
+			Tags:         colorTags,
+			IncludeTags:  tmEmpty,
+			ExcludeTags:  tmRGB,
+			ShouldManage: false,
+		},
+		{
+			Desc:         "no exclude by tag (no include)",
+			Tags:         colorTags,
+			IncludeTags:  tmEmpty,
+			ExcludeTags:  tmBar,
+			ShouldManage: true,
+		},
+		{
+			Desc:         "include by tag, single match (no exclude)",
+			Tags:         metasynTags,
+			IncludeTags:  tmBar,
+			ExcludeTags:  tmEmpty,
+			ShouldManage: true,
+		},
+		{
+			Desc:         "include by tag, multi match (no exclude)",
+			Tags:         colorTags,
+			IncludeTags:  tmRGB,
+			ExcludeTags:  tmEmpty,
+			ShouldManage: true,
+		},
+		{
+			Desc:         "no include by tag, multi match (missing tags, no exclude)",
+			Tags:         []Tag{{"red", ""}},
+			IncludeTags:  tmRGB,
+			ExcludeTags:  tmEmpty,
+			ShouldManage: false,
+		},
+		{
+			Desc:         "include by tag, mismatch exclude",
+			Tags:         metasynTags,
+			IncludeTags:  tmBar,
+			ExcludeTags:  tmRGB,
+			ShouldManage: true,
+		},
+		{
+			Desc:         "include by tag, exclude by single matching",
+			Tags:         append(metasynTags, Tag{"green", ""}),
+			IncludeTags:  tmBar,
+			ExcludeTags:  tmRGB,
+			ShouldManage: false,
+		},
+	} {
+		opts := Options{
+			IncludeTags: tc.IncludeTags,
+			ExcludeTags: tc.ExcludeTags,
+		}
+		managed := opts.ManagedPerTags(tc.Tags)
+		if managed != tc.ShouldManage {
+			t.Errorf("\"%v\": managed: expected=%v, got=%v", tc.Desc, tc.ShouldManage, managed)
+		}
+	}
+}
+
+func TestIncrementalFetchTags(t *testing.T) {
+	tagMap := map[string][]Tag{"a": nil, "b": nil, "c": nil, "d": nil, "e": nil}
+	funcCalls := 0
+	processedIDs := 0
+
+	err := incrementalFetchTags(tagMap, 2, func(ids []*string) error {
+		funcCalls++
+		if len(ids) > 2 {
+			t.Errorf("invalid number of ids in function call: expected<=%d, got=%d", 2, len(ids))
+		}
+		for _, id := range ids {
+			processedIDs++
+			name := aws.StringValue(id)
+			if _, ok := tagMap[name]; !ok {
+				t.Errorf("id not in tag map: %v", id)
+				continue
+			}
+			tagMap[name] = append(tagMap[name], Tag{"seen", "true"})
+		}
+		return nil
+	})
+	if err != nil {
+		t.Errorf("incrementalFetchTags: unexpected error: %v", err)
+	}
+	if funcCalls != 3 {
+		t.Errorf("func called incorrect number of times: expected=%d, got=%d", 3, funcCalls)
+	}
+	if processedIDs != len(tagMap) {
+		t.Errorf("unexpected number of processed ids: expected=%d, got=%d", len(tagMap), processedIDs)
+	}
+	for key, tags := range tagMap {
+		if len(tags) != 1 {
+			t.Errorf("expected 1 tag for key %s, got tags=%v", key, tags)
+		}
+	}
+}

--- a/aws-janitor/resources/volumes.go
+++ b/aws-janitor/resources/volumes.go
@@ -38,7 +38,8 @@ func (Volumes) MarkAndSweep(opts Options, set *Set) error {
 	pageFunc := func(page *ec2.DescribeVolumesOutput, _ bool) bool {
 		for _, vol := range page.Volumes {
 			v := &volume{Account: opts.Account, Region: opts.Region, ID: *vol.VolumeId}
-			if !set.Mark(opts, v, vol.CreateTime, fromEC2Tags(vol.Tags)) {
+			tags := fromEC2Tags(vol.Tags)
+			if !set.Mark(opts, v, vol.CreateTime, tags) {
 				continue
 			}
 			// Since tags and other metadata may not propagate to volumes from their attachments,
@@ -47,7 +48,7 @@ func (Volumes) MarkAndSweep(opts Options, set *Set) error {
 			if len(vol.Attachments) > 0 {
 				continue
 			}
-			logger.Warningf("%s: deleting %T: %s", v.ARN(), vol, v.ID)
+			logger.Warningf("%s: deleting %T: %s (%s)", v.ARN(), vol, v.ID, tags[NameTagKey])
 			if !opts.DryRun {
 				toDelete = append(toDelete, v)
 			}

--- a/aws-janitor/resources/volumes.go
+++ b/aws-janitor/resources/volumes.go
@@ -38,11 +38,18 @@ func (Volumes) MarkAndSweep(opts Options, set *Set) error {
 	pageFunc := func(page *ec2.DescribeVolumesOutput, _ bool) bool {
 		for _, vol := range page.Volumes {
 			v := &volume{Account: opts.Account, Region: opts.Region, ID: *vol.VolumeId}
-			if set.Mark(v, vol.CreateTime) {
-				logger.Warningf("%s: deleting %T: %s", v.ARN(), vol, v.ID)
-				if !opts.DryRun {
-					toDelete = append(toDelete, v)
-				}
+			if !set.Mark(opts, v, vol.CreateTime, fromEC2Tags(vol.Tags)) {
+				continue
+			}
+			// Since tags and other metadata may not propagate to volumes from their attachments,
+			// we avoid deleting any volume that is currently attached. Once their attached resource is deleted,
+			// we can safely delete volumes in a later clean-up run (using the mark data we saved in this run).
+			if len(vol.Attachments) > 0 {
+				continue
+			}
+			logger.Warningf("%s: deleting %T: %s", v.ARN(), vol, v.ID)
+			if !opts.DryRun {
+				toDelete = append(toDelete, v)
 			}
 		}
 		return true

--- a/aws-janitor/resources/vpcs.go
+++ b/aws-janitor/resources/vpcs.go
@@ -48,7 +48,7 @@ func (VPCs) MarkAndSweep(opts Options, set *Set) error {
 
 	for _, vp := range resp.Vpcs {
 		v := &vpc{Account: opts.Account, Region: opts.Region, ID: *vp.VpcId}
-		if !set.Mark(v, nil) {
+		if !set.Mark(opts, v, nil, fromEC2Tags(vp.Tags)) {
 			continue
 		}
 		logger.Warningf("%s: deleting %T: %s", v.ARN(), vp, v.ID)

--- a/aws-janitor/resources/vpcs.go
+++ b/aws-janitor/resources/vpcs.go
@@ -48,10 +48,11 @@ func (VPCs) MarkAndSweep(opts Options, set *Set) error {
 
 	for _, vp := range resp.Vpcs {
 		v := &vpc{Account: opts.Account, Region: opts.Region, ID: *vp.VpcId}
-		if !set.Mark(opts, v, nil, fromEC2Tags(vp.Tags)) {
+		tags := fromEC2Tags(vp.Tags)
+		if !set.Mark(opts, v, nil, tags) {
 			continue
 		}
-		logger.Warningf("%s: deleting %T: %s", v.ARN(), vp, v.ID)
+		logger.Warningf("%s: deleting %T: %s (%s)", v.ARN(), vp, v.ID, tags[NameTagKey])
 		if opts.DryRun {
 			continue
 		}


### PR DESCRIPTION
This PR adds support for tags on AWS resources to the AWS janitor.

This is applied in the following ways:
- A configurable list of "include" tags. Only if a resource matches all configured "include" tags will it be managed (i.e. deleted) by the janitor.
- A configurable list of "exclude" tags. A resource with any tags matching any of the supplied "exclude" tags will not be managed (i.e. deleted) by the janitor. Note that exclusion takes precedence over inclusion.
- A configurable TTL tag key. If a resource has a tag matching this key, then the value of that key will override the global TTL for that resource (unless the global TTL is set to 0, i.e. to delete all resources).

This change is a bit large, but I've attempted to break it into multiple commits to make it a bit easier to review.

/assign @richardcase @randomvariable
cc @chemikadze