### PR TITLE
aws-janitor: add job duration metric

### DIFF
--- a/cmd/aws-janitor/main.go
+++ b/cmd/aws-janitor/main.go
@@ -19,13 +19,19 @@ package main
 import (
 	"flag"
 	"fmt"
+	"os"
+	"runtime"
 	"time"
 
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/aws/session"
 	"github.com/pkg/errors"
+	"github.com/prometheus/client_golang/prometheus"
+	"github.com/prometheus/client_golang/prometheus/push"
 	"github.com/sirupsen/logrus"
+
 	"k8s.io/test-infra/prow/logrusutil"
+
 	"sigs.k8s.io/boskos/aws-janitor/account"
 	"sigs.k8s.io/boskos/aws-janitor/regions"
 	"sigs.k8s.io/boskos/aws-janitor/resources"
@@ -34,16 +40,23 @@ import (
 )
 
 var (
-	maxTTL    = flag.Duration("ttl", 24*time.Hour, "Maximum time before attempting to delete a resource. Set to 0s to nuke all non-default resources.")
-	region    = flag.String("region", "", "The region to clean (otherwise defaults to all regions)")
-	path      = flag.String("path", "", "S3 path for mark data (required when -all=false)")
-	cleanAll  = flag.Bool("all", false, "Clean all resources (ignores -path)")
-	logLevel  = flag.String("log-level", "info", fmt.Sprintf("Log level is one of %v.", logrus.AllLevels))
-	dryRun    = flag.Bool("dry-run", false, "If set, don't delete any resources, only log what would be done")
-	ttlTagKey = flag.String("ttl-tag-key", "", "If set, allow resources to use a tag with this key to override TTL")
+	maxTTL      = flag.Duration("ttl", 24*time.Hour, "Maximum time before attempting to delete a resource. Set to 0s to nuke all non-default resources.")
+	region      = flag.String("region", "", "The region to clean (otherwise defaults to all regions)")
+	path        = flag.String("path", "", "S3 path for mark data (required when -all=false)")
+	cleanAll    = flag.Bool("all", false, "Clean all resources (ignores -path)")
+	logLevel    = flag.String("log-level", "info", fmt.Sprintf("Log level is one of %v.", logrus.AllLevels))
+	dryRun      = flag.Bool("dry-run", false, "If set, don't delete any resources, only log what would be done")
+	ttlTagKey   = flag.String("ttl-tag-key", "", "If set, allow resources to use a tag with this key to override TTL")
+	pushGateway = flag.String("push-gateway", "", "If specified, push prometheus metrics to this endpoint.")
 
 	excludeTags common.CommaSeparatedStrings
 	includeTags common.CommaSeparatedStrings
+
+	cleaningTimeHistogram = prometheus.NewHistogramVec(prometheus.HistogramOpts{
+		Name:        "aws_janitor_job_duration_time_seconds",
+		ConstLabels: prometheus.Labels{},
+		Buckets:     prometheus.ExponentialBuckets(1, 1.4, 30),
+	}, []string{"type", "status"})
 )
 
 func init() {
@@ -63,6 +76,26 @@ func main() {
 	}
 	logrus.SetLevel(level)
 
+	// If Prometheus PushGateway is configured, then before exit push the metric
+	// to the PushGateway instance, otherwise just exit
+	exitCode := 2
+	startProcess := time.Now()
+	if *pushGateway != "" {
+		jobName := fmt.Sprintf("aws-janitor-%s", common.GenerateDynamicResourceName())
+		registry := prometheus.NewRegistry()
+		registry.MustRegister(cleaningTimeHistogram)
+		pusher := push.New(*pushGateway, jobName).Gatherer(registry)
+
+		defer func() {
+			pushMetricBeforeExit(pusher, startProcess, *cleanAll, exitCode)
+			os.Exit(exitCode)
+		}()
+	} else {
+		defer func() {
+			os.Exit(exitCode)
+		}()
+	}
+
 	// Retry aggressively (with default back-off). If the account is
 	// in a really bad state, we may be contending with API rate
 	// limiting and fighting against the very resources we're trying
@@ -70,17 +103,20 @@ func main() {
 	sess := session.Must(session.NewSessionWithOptions(session.Options{Config: aws.Config{MaxRetries: aws.Int(100)}}))
 	acct, err := account.GetAccount(sess, regions.Default)
 	if err != nil {
-		logrus.Fatalf("Failed retrieving account: %v", err)
+		logrus.Errorf("Failed retrieving account: %v", err)
+		runtime.Goexit()
 	}
 	logrus.Debugf("account: %s", acct)
 
 	excludeTM, err := resources.TagMatcherForTags(excludeTags)
 	if err != nil {
-		logrus.Fatalf("Error parsing --exclude-tags: %v", err)
+		logrus.Errorf("Error parsing --exclude-tags: %v", err)
+		runtime.Goexit()
 	}
 	includeTM, err := resources.TagMatcherForTags(includeTags)
 	if err != nil {
-		logrus.Fatalf("Error parsing --include-tags: %v", err)
+		logrus.Errorf("Error parsing --include-tags: %v", err)
+		runtime.Goexit()
 	}
 
 	opts := resources.Options{
@@ -94,11 +130,15 @@ func main() {
 
 	if *cleanAll {
 		if err := resources.CleanAll(opts, *region); err != nil {
-			logrus.Fatalf("Error cleaning all resources: %v", err)
+			logrus.Errorf("Error cleaning all resources: %v", err)
+			runtime.Goexit()
 		}
 	} else if err := markAndSweep(opts, *region); err != nil {
-		logrus.Fatalf("Error marking and sweeping resources: %v", err)
+		logrus.Errorf("Error marking and sweeping resources: %v", err)
+		runtime.Goexit()
 	}
+
+	exitCode = 0
 }
 
 func markAndSweep(opts resources.Options, region string) error {
@@ -142,4 +182,25 @@ func markAndSweep(opts resources.Options, region string) error {
 	logrus.Infof("swept %d resources", swept)
 
 	return nil
+}
+
+func pushMetricBeforeExit(pusher *push.Pusher, startTime time.Time, jobType bool, exitCode int) {
+	// Set the status of the job
+	status := "failed"
+	if exitCode == 0 {
+		status = "success"
+	}
+
+	// Set the type of the job to report the metric
+	job := "sweep"
+	if jobType {
+		job = "clean"
+	}
+
+	duration := time.Since(startTime).Seconds()
+	cleaningTimeHistogram.WithLabelValues(job, status).Observe(duration)
+
+	if err := pusher.Add(); err != nil {
+		logrus.Errorf("Could not push to Pushgateway: %v", err)
+	}
 }


### PR DESCRIPTION
...to collect the response time when running this job


this is a short live job, and then we cannot guarantee that we will have someone to scrape the data at the correct time, to avoid that, we need to use the Prometheus PushGateway to store the metrics and then have Prometheus scrape the PushGateway, however, the problem continues, we need to make sure the metrics are pushed to the PushGateway in time.

So for that, we need to push ourselves, then the approach in this PR is to push when exiting the job

this is part of https://github.com/kubernetes-sigs/boskos/issues/13

opening this PR for feedback and see if sounds good

a screenshot for the metric pushed to PushGateway

![Screen Shot 2021-03-04 at 14 00 38](https://user-images.githubusercontent.com/4115580/109969106-cc373780-7cf3-11eb-865d-182ba6715d51.png)


/assign @ixdy 