### PR TITLE
aws-janitor: Route53 Improvements

### DIFF
--- a/aws-janitor/resources/route53.go
+++ b/aws-janitor/resources/route53.go
@@ -95,6 +95,9 @@ func route53ResourceRecordSetsForZone(opts Options, logger logrus.FieldLogger, s
 				continue
 			}
 			logger.Warningf("%s: deleting %T: %s", o.ARN(), rrs, *rrs.Name)
+			if !opts.DryRun {
+				toDelete = append(toDelete, o)
+			}
 		}
 		return true
 	}

--- a/aws-janitor/resources/route53.go
+++ b/aws-janitor/resources/route53.go
@@ -55,6 +55,9 @@ var managedNameRegexes = []*regexp.Regexp{
 
 	// e.g. etcd-events-b.internal.e2e-71149fffac-dba53.test-cncf-aws.k8s.io.
 	regexp.MustCompile(`^etcd-events-[a-z]\.internal\.e2e-[0-9a-z]{1,10}-[0-9a-f]{5}\.`),
+
+	// e.g. kops-controller.internal.e2e-71149fffac-dba53.test-cncf-aws.k8s.io.
+	regexp.MustCompile(`^kops-controller\.internal\.e2e-[0-9a-z]{1,10}-[0-9a-f]{5}\.`),
 }
 
 // resourceRecordSetIsManaged checks if the resource record should be managed (and thus deleted) by us

--- a/aws-janitor/resources/route53.go
+++ b/aws-janitor/resources/route53.go
@@ -19,6 +19,7 @@ package resources
 import (
 	"fmt"
 	"regexp"
+	"strings"
 	"time"
 
 	"github.com/aws/aws-sdk-go/aws"
@@ -189,6 +190,9 @@ func (Route53ResourceRecordSets) ListAll(opts Options) (*Set, error) {
 			if !zoneIsManaged(zone) {
 				continue
 			}
+			// ListHostedZones returns "/hostedzone/ABCDEF12345678" but other Route53 endpoints expect "ABCDEF12345678"
+			zone.Id = aws.String(strings.TrimPrefix(aws.StringValue(zone.Id), "/hostedzone/"))
+
 			inp := &route53.ListResourceRecordSetsInput{HostedZoneId: z.Id}
 			err := svc.ListResourceRecordSetsPages(inp, func(recordSets *route53.ListResourceRecordSetsOutput, _ bool) bool {
 				now := time.Now()


### PR DESCRIPTION
* Strip the `/hostedzone/` prefix from zone IDs returned by ListHostedZones before passing them to other route53 API requests. This is due to an inconsistency in the Route53 API.

  aws-janitor jobs are [currently failing](https://prow.k8s.io/view/gs/kubernetes-jenkins/logs/maintenance-ci-aws-janitor/1383470582967832576#1:build-log.txt%3A38) with this error: `No hosted zone found with ID: /hostedzone/ZEMLNXIIWQ0RV`.

  Local testing confirms that `ListHostedZones` returns an ID of the form `/hostedzone/ABCDEF12345678` but `ListTagsForResources` expects IDs of the form `ABCDEF12345678`, otherwise it returns an error.

* Ensure kops-controller DNS records are also deleted. [Recent kops versions create these records](https://github.com/kubernetes/kops/blob/27f05ca939b758379ed9cb8a1cbbd6fa0d8db7bc/upup/pkg/fi/cloudup/dns.go#L265).

* Actually delete Route53 records. The `toDelete` slice was otherwise untouched before being returned. This updates route53ResourceRecordSet to match other resource types: https://github.com/kubernetes-sigs/boskos/blob/69ca1dfe2f87c788df33b54a4b545df00c0898a8/aws-janitor/resources/iam_roles.go#L94-L96