### PR TITLE
aws-janitor: trim hostedzone ID prefix in MarkAndSweep

### DIFF
--- a/aws-janitor/resources/route53.go
+++ b/aws-janitor/resources/route53.go
@@ -123,6 +123,9 @@ func (rrs Route53ResourceRecordSets) MarkAndSweep(opts Options, set *Set) error 
 				continue
 			}
 
+			// ListHostedZones returns "/hostedzone/ABCDEF12345678" but other Route53 endpoints expect "ABCDEF12345678"
+			z.Id = aws.String(strings.TrimPrefix(aws.StringValue(z.Id), "/hostedzone/"))
+
 			zones = append(zones, z)
 			zoneTags[aws.StringValue(z.Id)] = nil
 		}


### PR DESCRIPTION
Followup to https://github.com/kubernetes-sigs/boskos/pull/80

aws-janitor jobs are [still failing with the same error](https://prow.k8s.io/view/gs/kubernetes-jenkins/logs/maintenance-ci-aws-janitor/1384259018888843264). It seems that we need to fix the ListHostedZones output in MarkAndSweep in addition to ListAll.