### PR TITLE
aws-janitor - Update Route53 name regexes for kOps' new etcd format

### DIFF
--- a/aws-janitor/resources/route53.go
+++ b/aws-janitor/resources/route53.go
@@ -51,11 +51,11 @@ var managedNameRegexes = []*regexp.Regexp{
 	// e.g. api.internal.e2e-71149fffac-dba53.test-cncf-aws.k8s.io.
 	regexp.MustCompile(`^api\.internal\.e2e-[0-9a-z]{1,10}-[0-9a-f]{5}\.`),
 
-	// e.g. etcd-b.internal.e2e-71149fffac-dba53.test-cncf-aws.k8s.io.
-	regexp.MustCompile(`^etcd-[a-z]\.internal\.e2e-[0-9a-z]{1,10}-[0-9a-f]{5}\.`),
+	// e.g. main.etcd.e2e-71149fffac-dba53.test-cncf-aws.k8s.io.
+	regexp.MustCompile(`^main\.etcd\.e2e-[0-9a-z]{1,10}-[0-9a-f]{5}\.`),
 
-	// e.g. etcd-events-b.internal.e2e-71149fffac-dba53.test-cncf-aws.k8s.io.
-	regexp.MustCompile(`^etcd-events-[a-z]\.internal\.e2e-[0-9a-z]{1,10}-[0-9a-f]{5}\.`),
+	// e.g. events.etcd.e2e-71149fffac-dba53.test-cncf-aws.k8s.io.
+	regexp.MustCompile(`^events\.etcd\.e2e-[0-9a-z]{1,10}-[0-9a-f]{5}\.`),
 
 	// e.g. kops-controller.internal.e2e-71149fffac-dba53.test-cncf-aws.k8s.io.
 	regexp.MustCompile(`^kops-controller\.internal\.e2e-[0-9a-z]{1,10}-[0-9a-f]{5}\.`),

--- a/aws-janitor/resources/route53_test.go
+++ b/aws-janitor/resources/route53_test.go
@@ -37,11 +37,11 @@ func TestManagedNames(t *testing.T) {
 			expected: true,
 		},
 		{
-			rrs:      &route53.ResourceRecordSet{Type: aws.String("A"), Name: aws.String("etcd-b.internal.e2e-71149fffac-dba53.test-cncf-aws.k8s.io.")},
+			rrs:      &route53.ResourceRecordSet{Type: aws.String("A"), Name: aws.String("main.etcd.e2e-71149fffac-dba53.test-cncf-aws.k8s.io.")},
 			expected: true,
 		},
 		{
-			rrs:      &route53.ResourceRecordSet{Type: aws.String("A"), Name: aws.String("etcd-events-b.internal.e2e-71149fffac-dba53.test-cncf-aws.k8s.io.")},
+			rrs:      &route53.ResourceRecordSet{Type: aws.String("A"), Name: aws.String("events.etcd.e2e-71149fffac-dba53.test-cncf-aws.k8s.io.")},
 			expected: true,
 		},
 		{


### PR DESCRIPTION
This updates the Route53 record pattern for kOps' etcd records - these records were only used by kOps' legacy etcd implementation (before etcd-manager). See [this](https://github.com/kubernetes/kops/blob/06ca1ff169af82f78c59ffc17cf966fdd2b74898/upup/pkg/fi/cloudup/dns.go#L250-L261) code block and know that we don't have any prow jobs that test legacy etcd anymore, it will be removed altogether soon.

The new etcd format is what kOps creates when provisioning dedicated apiservers that connect to etcd remotely. See [this](https://github.com/kubernetes/kops/blob/044a59ab97dc1407f45f13aba5d707677be8c020/nodeup/pkg/model/kube_apiserver.go#L322-L323) code block.

The [aws-janitor logs](https://prow.k8s.io/view/gs/kubernetes-jenkins/logs/maintenance-ci-aws-janitor/1384654184124518400) mention ignoring the new etcd format for clusters created by presubmit jobs, which should be swept. This PR intends to cleanup these records, reducing the number of "Ignoring unmanaged name" lines in the logs.
