### PR TITLE
Oneshot mode for aws-janitor

### DIFF
--- a/aws-janitor/resources/addresses.go
+++ b/aws-janitor/resources/addresses.go
@@ -66,7 +66,7 @@ func (Addresses) MarkAndSweep(opts Options, set *Set) error {
 
 func (Addresses) ListAll(opts Options) (*Set, error) {
 	svc := ec2.New(opts.Session, aws.NewConfig().WithRegion(opts.Region))
-	set := NewSet(0)
+	set := NewSet(opts.DefaultTTL)
 	inp := &ec2.DescribeAddressesInput{}
 
 	addrs, err := svc.DescribeAddresses(inp)

--- a/aws-janitor/resources/asg.go
+++ b/aws-janitor/resources/asg.go
@@ -92,7 +92,7 @@ func (AutoScalingGroups) MarkAndSweep(opts Options, set *Set) error {
 
 func (AutoScalingGroups) ListAll(opts Options) (*Set, error) {
 	c := autoscaling.New(opts.Session, aws.NewConfig().WithRegion(opts.Region))
-	set := NewSet(0)
+	set := NewSet(opts.DefaultTTL)
 	input := &autoscaling.DescribeAutoScalingGroupsInput{}
 
 	err := c.DescribeAutoScalingGroupsPages(input, func(asgs *autoscaling.DescribeAutoScalingGroupsOutput, isLast bool) bool {

--- a/aws-janitor/resources/cloud_formation_stacks.go
+++ b/aws-janitor/resources/cloud_formation_stacks.go
@@ -103,7 +103,7 @@ func (cfs CloudFormationStacks) MarkAndSweep(opts Options, set *Set) error {
 
 func (CloudFormationStacks) ListAll(opts Options) (*Set, error) {
 	svc := cf.New(opts.Session, aws.NewConfig().WithRegion(opts.Region))
-	set := NewSet(0)
+	set := NewSet(opts.DefaultTTL)
 	inp := &cf.ListStacksInput{}
 
 	err := svc.ListStacksPages(inp, func(stacks *cf.ListStacksOutput, _ bool) bool {

--- a/aws-janitor/resources/dhcp_options.go
+++ b/aws-janitor/resources/dhcp_options.go
@@ -97,7 +97,7 @@ func (DHCPOptions) MarkAndSweep(opts Options, set *Set) error {
 
 func (DHCPOptions) ListAll(opts Options) (*Set, error) {
 	svc := ec2.New(opts.Session, aws.NewConfig().WithRegion(opts.Region))
-	set := NewSet(0)
+	set := NewSet(opts.DefaultTTL)
 	inp := &ec2.DescribeDhcpOptionsInput{}
 
 	optsList, err := svc.DescribeDhcpOptions(inp)

--- a/aws-janitor/resources/efs.go
+++ b/aws-janitor/resources/efs.go
@@ -112,7 +112,7 @@ func (ElasticFileSystems) MarkAndSweep(opts Options, set *Set) error {
 
 func (ElasticFileSystems) ListAll(opts Options) (*Set, error) {
 	svc := efs.New(opts.Session, aws.NewConfig().WithRegion(opts.Region))
-	set := NewSet(0)
+	set := NewSet(opts.DefaultTTL)
 	input := &efs.DescribeFileSystemsInput{}
 
 	err := svc.DescribeFileSystemsPages(input, func(page *efs.DescribeFileSystemsOutput, _ bool) bool {

--- a/aws-janitor/resources/eks.go
+++ b/aws-janitor/resources/eks.go
@@ -59,7 +59,7 @@ func (e EKS) MarkAndSweep(opts Options, set *Set) error {
 
 func (e EKS) ListAll(opts Options) (*Set, error) {
 	svc := eks.New(opts.Session, aws.NewConfig().WithRegion(opts.Region))
-	set := NewSet(0)
+	set := NewSet(opts.DefaultTTL)
 	err := e.describeClusters(opts, set, svc, func(_ *eksCluster) {})
 	return set, err
 }

--- a/aws-janitor/resources/elb.go
+++ b/aws-janitor/resources/elb.go
@@ -108,7 +108,7 @@ func (ClassicLoadBalancers) MarkAndSweep(opts Options, set *Set) error {
 
 func (ClassicLoadBalancers) ListAll(opts Options) (*Set, error) {
 	c := elb.New(opts.Session, aws.NewConfig().WithRegion(opts.Region))
-	set := NewSet(0)
+	set := NewSet(opts.DefaultTTL)
 	input := &elb.DescribeLoadBalancersInput{}
 
 	err := c.DescribeLoadBalancersPages(input, func(lbs *elb.DescribeLoadBalancersOutput, isLast bool) bool {

--- a/aws-janitor/resources/elbv2.go
+++ b/aws-janitor/resources/elbv2.go
@@ -107,7 +107,7 @@ func (LoadBalancers) MarkAndSweep(opts Options, set *Set) error {
 
 func (LoadBalancers) ListAll(opts Options) (*Set, error) {
 	c := elbv2.New(opts.Session, aws.NewConfig().WithRegion(opts.Region))
-	set := NewSet(0)
+	set := NewSet(opts.DefaultTTL)
 	input := &elbv2.DescribeLoadBalancersInput{}
 
 	err := c.DescribeLoadBalancersPages(input, func(lbs *elbv2.DescribeLoadBalancersOutput, isLast bool) bool {

--- a/aws-janitor/resources/iam_instance_profiles.go
+++ b/aws-janitor/resources/iam_instance_profiles.go
@@ -99,7 +99,7 @@ func (IAMInstanceProfiles) MarkAndSweep(opts Options, set *Set) error {
 
 func (IAMInstanceProfiles) ListAll(opts Options) (*Set, error) {
 	svc := iam.New(opts.Session, aws.NewConfig().WithRegion(opts.Region))
-	set := NewSet(0)
+	set := NewSet(opts.DefaultTTL)
 	inp := &iam.ListInstanceProfilesInput{}
 
 	err := svc.ListInstanceProfilesPages(inp, func(profiles *iam.ListInstanceProfilesOutput, _ bool) bool {

--- a/aws-janitor/resources/iam_roles.go
+++ b/aws-janitor/resources/iam_roles.go
@@ -114,7 +114,7 @@ func (IAMRoles) MarkAndSweep(opts Options, set *Set) error {
 
 func (IAMRoles) ListAll(opts Options) (*Set, error) {
 	svc := iam.New(opts.Session, aws.NewConfig().WithRegion(opts.Region))
-	set := NewSet(0)
+	set := NewSet(opts.DefaultTTL)
 	inp := &iam.ListRolesInput{}
 
 	err := svc.ListRolesPages(inp, func(roles *iam.ListRolesOutput, _ bool) bool {

--- a/aws-janitor/resources/instance.go
+++ b/aws-janitor/resources/instance.go
@@ -86,7 +86,7 @@ func (Instances) MarkAndSweep(opts Options, set *Set) error {
 
 func (Instances) ListAll(opts Options) (*Set, error) {
 	svc := ec2.New(opts.Session, aws.NewConfig().WithRegion(opts.Region))
-	set := NewSet(0)
+	set := NewSet(opts.DefaultTTL)
 	inp := &ec2.DescribeInstancesInput{}
 
 	err := svc.DescribeInstancesPages(inp, func(instances *ec2.DescribeInstancesOutput, _ bool) bool {

--- a/aws-janitor/resources/internet_gateways.go
+++ b/aws-janitor/resources/internet_gateways.go
@@ -106,7 +106,7 @@ func (InternetGateways) MarkAndSweep(opts Options, set *Set) error {
 
 func (InternetGateways) ListAll(opts Options) (*Set, error) {
 	svc := ec2.New(opts.Session, aws.NewConfig().WithRegion(opts.Region))
-	set := NewSet(0)
+	set := NewSet(opts.DefaultTTL)
 	input := &ec2.DescribeInternetGatewaysInput{}
 
 	gateways, err := svc.DescribeInternetGateways(input)

--- a/aws-janitor/resources/launch_configs.go
+++ b/aws-janitor/resources/launch_configs.go
@@ -70,7 +70,7 @@ func (LaunchConfigurations) MarkAndSweep(opts Options, set *Set) error {
 
 func (LaunchConfigurations) ListAll(opts Options) (*Set, error) {
 	c := autoscaling.New(opts.Session, aws.NewConfig().WithRegion(opts.Region))
-	set := NewSet(0)
+	set := NewSet(opts.DefaultTTL)
 	input := &autoscaling.DescribeLaunchConfigurationsInput{}
 
 	err := c.DescribeLaunchConfigurationsPages(input, func(lcs *autoscaling.DescribeLaunchConfigurationsOutput, isLast bool) bool {

--- a/aws-janitor/resources/launch_templates.go
+++ b/aws-janitor/resources/launch_templates.go
@@ -73,7 +73,7 @@ func (LaunchTemplates) MarkAndSweep(opts Options, set *Set) error {
 
 func (LaunchTemplates) ListAll(opts Options) (*Set, error) {
 	c := ec2.New(opts.Session, aws.NewConfig().WithRegion(opts.Region))
-	set := NewSet(0)
+	set := NewSet(opts.DefaultTTL)
 	input := &ec2.DescribeLaunchTemplatesInput{}
 
 	err := c.DescribeLaunchTemplatesPages(input, func(lts *ec2.DescribeLaunchTemplatesOutput, isLast bool) bool {

--- a/aws-janitor/resources/list.go
+++ b/aws-janitor/resources/list.go
@@ -17,6 +17,8 @@ limitations under the License.
 package resources
 
 import (
+	"time"
+
 	"github.com/aws/aws-sdk-go/aws/session"
 )
 
@@ -36,6 +38,9 @@ type Options struct {
 	// If set, any resources with a tag matching this key can override the global TTL (unless the global TTL is 0).
 	// The value of the tag must be a valid Go time.Duration string.
 	TTLTagKey string
+
+	// Default TTL for the resource at ListAll phase.
+	DefaultTTL time.Duration
 
 	// Whether to actually delete resources, or just report what would be deleted.
 	DryRun bool

--- a/aws-janitor/resources/nat_gateway.go
+++ b/aws-janitor/resources/nat_gateway.go
@@ -69,7 +69,7 @@ func (NATGateway) MarkAndSweep(opts Options, set *Set) error {
 // ListAll populates a set will all available NATGateway resources.
 func (NATGateway) ListAll(opts Options) (*Set, error) {
 	svc := ec2.New(opts.Session, aws.NewConfig().WithRegion(opts.Region))
-	set := NewSet(0)
+	set := NewSet(opts.DefaultTTL)
 	inp := &ec2.DescribeNatGatewaysInput{}
 
 	err := svc.DescribeNatGatewaysPages(inp, func(page *ec2.DescribeNatGatewaysOutput, _ bool) bool {

--- a/aws-janitor/resources/network_interface.go
+++ b/aws-janitor/resources/network_interface.go
@@ -82,7 +82,7 @@ func (NetworkInterfaces) MarkAndSweep(opts Options, set *Set) error {
 
 func (NetworkInterfaces) ListAll(opts Options) (*Set, error) {
 	c := ec2.New(opts.Session, aws.NewConfig().WithRegion(opts.Region))
-	set := NewSet(0)
+	set := NewSet(opts.DefaultTTL)
 	input := &ec2.DescribeNetworkInterfacesInput{}
 
 	err := c.DescribeNetworkInterfacesPages(input, func(enis *ec2.DescribeNetworkInterfacesOutput, isLast bool) bool {

--- a/aws-janitor/resources/route53.go
+++ b/aws-janitor/resources/route53.go
@@ -187,7 +187,7 @@ func (rrs Route53ResourceRecordSets) MarkAndSweep(opts Options, set *Set) error 
 
 func (Route53ResourceRecordSets) ListAll(opts Options) (*Set, error) {
 	svc := route53.New(opts.Session, aws.NewConfig().WithRegion(opts.Region))
-	set := NewSet(0)
+	set := NewSet(opts.DefaultTTL)
 
 	var rrsErr error
 	err := svc.ListHostedZonesPages(&route53.ListHostedZonesInput{}, func(zones *route53.ListHostedZonesOutput, _ bool) bool {

--- a/aws-janitor/resources/route_tables.go
+++ b/aws-janitor/resources/route_tables.go
@@ -89,7 +89,7 @@ func (RouteTables) MarkAndSweep(opts Options, set *Set) error {
 
 func (RouteTables) ListAll(opts Options) (*Set, error) {
 	svc := ec2.New(opts.Session, aws.NewConfig().WithRegion(opts.Region))
-	set := NewSet(0)
+	set := NewSet(opts.DefaultTTL)
 	input := &ec2.DescribeRouteTablesInput{}
 
 	err := svc.DescribeRouteTablesPages(input, func(tables *ec2.DescribeRouteTablesOutput, _ bool) bool {

--- a/aws-janitor/resources/security_groups.go
+++ b/aws-janitor/resources/security_groups.go
@@ -120,7 +120,7 @@ func (SecurityGroups) MarkAndSweep(opts Options, set *Set) error {
 
 func (SecurityGroups) ListAll(opts Options) (*Set, error) {
 	svc := ec2.New(opts.Session, aws.NewConfig().WithRegion(opts.Region))
-	set := NewSet(0)
+	set := NewSet(opts.DefaultTTL)
 	input := &ec2.DescribeSecurityGroupsInput{}
 
 	err := svc.DescribeSecurityGroupsPages(input, func(groups *ec2.DescribeSecurityGroupsOutput, _ bool) bool {

--- a/aws-janitor/resources/snapshots.go
+++ b/aws-janitor/resources/snapshots.go
@@ -80,7 +80,7 @@ func (Snapshots) MarkAndSweep(opts Options, set *Set) error {
 
 func (Snapshots) ListAll(opts Options) (*Set, error) {
 	c := ec2.New(opts.Session, aws.NewConfig().WithRegion(opts.Region))
-	set := NewSet(0)
+	set := NewSet(opts.DefaultTTL)
 	input := &ec2.DescribeSnapshotsInput{
 		// Exclude publicly-available snapshots from other owners.
 		OwnerIds: aws.StringSlice([]string{"self"}),

--- a/aws-janitor/resources/sqs.go
+++ b/aws-janitor/resources/sqs.go
@@ -147,7 +147,7 @@ func deleteEventBridgeRule(rule *string, svcRules *eventbridge.EventBridge, logg
 
 func (SQSQueues) ListAll(opts Options) (*Set, error) {
 	svc := sqs.New(opts.Session, aws.NewConfig().WithRegion(opts.Region))
-	set := NewSet(0)
+	set := NewSet(opts.DefaultTTL)
 	input := &sqs.ListQueuesInput{}
 
 	err := svc.ListQueuesPages(input, func(queues *sqs.ListQueuesOutput, _ bool) bool {

--- a/aws-janitor/resources/subnets.go
+++ b/aws-janitor/resources/subnets.go
@@ -68,7 +68,7 @@ func (Subnets) MarkAndSweep(opts Options, set *Set) error {
 
 func (Subnets) ListAll(opts Options) (*Set, error) {
 	svc := ec2.New(opts.Session, aws.NewConfig().WithRegion(opts.Region))
-	set := NewSet(0)
+	set := NewSet(opts.DefaultTTL)
 	input := &ec2.DescribeSubnetsInput{}
 
 	// Subnets not paginated

--- a/aws-janitor/resources/volumes.go
+++ b/aws-janitor/resources/volumes.go
@@ -75,7 +75,7 @@ func (Volumes) MarkAndSweep(opts Options, set *Set) error {
 
 func (Volumes) ListAll(opts Options) (*Set, error) {
 	svc := ec2.New(opts.Session, aws.NewConfig().WithRegion(opts.Region))
-	set := NewSet(0)
+	set := NewSet(opts.DefaultTTL)
 	inp := &ec2.DescribeVolumesInput{}
 
 	err := svc.DescribeVolumesPages(inp, func(vols *ec2.DescribeVolumesOutput, _ bool) bool {

--- a/aws-janitor/resources/vpcs.go
+++ b/aws-janitor/resources/vpcs.go
@@ -77,7 +77,7 @@ func (VPCs) MarkAndSweep(opts Options, set *Set) error {
 
 func (VPCs) ListAll(opts Options) (*Set, error) {
 	svc := ec2.New(opts.Session, aws.NewConfig().WithRegion(opts.Region))
-	set := NewSet(0)
+	set := NewSet(opts.DefaultTTL)
 	inp := &ec2.DescribeVpcsInput{}
 
 	vpcs, err := svc.DescribeVpcs(inp)


### PR DESCRIPTION
In some cases it is useful to run one-off cleanup of
existing resources without relying on s3 state, but
still honoring TTLs.

Also clarifies that -all ignores TTLs.