### PR TITLE
Fix build break in images/build.sh boskosctl

### DIFF
--- a/images/boskosctl/Dockerfile
+++ b/images/boskosctl/Dockerfile
@@ -32,6 +32,8 @@ COPY . .
 ARG DOCKER_TAG
 ENV DOCKER_TAG=${DOCKER_TAG}
 
+RUN apk add gcc musl-dev
+
 ARG cmd
 RUN make "${cmd}"
 


### PR DESCRIPTION
I see the following when building the image:

./images/build.sh boskosctl
Emulate Docker CLI using podman. Create /etc/containers/nodocker to quiet msg.
STEP 1: FROM golang:1.15.8-alpine3.12 AS build
...
/usr/local/go/pkg/tool/linux_ppc64le/link: running gcc failed: exec: "gcc": executable file not found in $PATH
make: *** [Makefile:48: boskosctl] Error 2
STEP 12: FROM alpine:3.12
Resolved "alpine" as an alias (/etc/containers/registries.conf.d/000-shortnames.conf)
Error: error building at STEP "RUN make "${cmd}"": error while running runtime: exit status 2
make: *** [Makefile:71: boskosctl-image] Error 125

and also the following when adding gcc package:

...
/usr/local/go/pkg/tool/linux_ppc64le/link: running gcc failed: exit status 1
/usr/lib/gcc/powerpc64le-alpine-linux-musl/9.3.0/../../../../powerpc64le-alpine-linux-musl/bin/ld: cannot find Scrt1.o: No such file or directory
/usr/lib/gcc/powerpc64le-alpine-linux-musl/9.3.0/../../../../powerpc64le-alpine-linux-musl/bin/ld: cannot find crti.o: No such file or directory
/usr/lib/gcc/powerpc64le-alpine-linux-musl/9.3.0/../../../../powerpc64le-alpine-linux-musl/bin/ld: cannot find -lpthread
/usr/lib/gcc/powerpc64le-alpine-linux-musl/9.3.0/../../../../powerpc64le-alpine-linux-musl/bin/ld: cannot find -lssp_nonshared
collect2: error: ld returned 1 exit status
...