### PR TITLE
Fix image build

### DIFF
--- a/images/boskosctl/Dockerfile
+++ b/images/boskosctl/Dockerfile
@@ -15,7 +15,7 @@
 # Installs a few extra tools folks might want to use when running boskosctl.
 
 ARG go_version
-ARG alpine_version=3.12
+ARG alpine_version=3.14
 
 FROM golang:${go_version}-alpine${alpine_version} as build
 WORKDIR /go/src/app


### PR DESCRIPTION
There is no golang:1.16.6-alpine3.12 image, just
golang:1.16.6-alpine3.14

Ref https://prow.k8s.io/view/gs/kubernetes-jenkins/logs/post-boskos-push-images/1421159064083107840 for the failing postsubmit