### PR TITLE
Add cleaner for libvirt CIs

### DIFF
--- a/cmd/libvirt-cleaner/cleaner.go
+++ b/cmd/libvirt-cleaner/cleaner.go
@@ -1,0 +1,181 @@
+/*
+Copyright 2020 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package main
+
+import (
+	"context"
+	"fmt"
+	"strings"
+
+	"github.com/sirupsen/logrus"
+	kerrors "k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/types"
+	v1 "k8s.io/api/core/v1"
+	ctrlruntimeclient "sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/controller"
+	"sigs.k8s.io/controller-runtime/pkg/handler"
+	"sigs.k8s.io/controller-runtime/pkg/manager"
+	"sigs.k8s.io/controller-runtime/pkg/reconcile"
+	"sigs.k8s.io/controller-runtime/pkg/source"
+
+	"sigs.k8s.io/boskos/cleaner"
+	"sigs.k8s.io/boskos/common"
+	"sigs.k8s.io/boskos/crds"
+)
+
+const controllerName = "boskos-libvirt-cleaner"
+
+// Add creates a new cleaner controller
+func Add(mgr manager.Manager, boskosClient cleaner.RecycleBoskosClient, namespace string) error {
+	reconciler := &reconciler{
+		ctx:          context.Background(),
+		client:       mgr.GetClient(),
+		boskosClient: boskosClient,
+		namespace:    namespace,
+	}
+
+	c, err := controller.New(controllerName, mgr, controller.Options{
+		Reconciler:              reconciler,
+		MaxConcurrentReconciles: 4,
+	})
+	if err != nil {
+		return fmt.Errorf("failed to create controller: %v", err)
+	}
+
+	if err := c.Watch(&source.Kind{Type: &crds.ResourceObject{}}, &handler.EnqueueRequestForObject{}); err != nil {
+		return fmt.Errorf("failed to create watch: %v", err)
+	}
+
+	return nil
+}
+
+type reconciler struct {
+	ctx          context.Context
+	client       ctrlruntimeclient.Client
+	boskosClient cleaner.RecycleBoskosClient
+	recycleFunc  func(cleaner.RecycleBoskosClient, *common.Resource)
+	namespace    string
+}
+
+func (r *reconciler) Reconcile(_ context.Context, request reconcile.Request) (reconcile.Result, error) {
+	// TODO(alvaroaleman): figure out how to use the context
+	log := logrus.WithField("resource-name", request.Name)
+	err := r.reconcile(log, request)
+	if err != nil {
+		log.WithError(err).Error("Reconciliation error")
+	}
+	return reconcile.Result{}, err
+}
+
+func (r *reconciler) shouldDeactivate () (bool, error) {
+	var err error = nil
+	var nn_should_deactivate = types.NamespacedName{Namespace: "ci", Name: "deactivate"}
+	var secret_should_deactivate v1.Secret
+
+	if err = r.client.Get(r.ctx, nn_should_deactivate, &secret_should_deactivate); err != nil {
+		if kerrors.IsNotFound(err) {
+			return false, nil
+		}
+		return false, fmt.Errorf("shouldDeactivate: Get: %v", err)
+	}
+
+	bytes_should_deactivate, ok := secret_should_deactivate.Data["data"]
+	if !ok {
+		logrus.Debugf ("shouldDeactivate: bytes_should_deactivate = %v, ok = %v", bytes_should_deactivate, ok)
+		return false, nil
+	}
+
+	string_should_deactivate := string(bytes_should_deactivate)
+	bool_should_deactivate := string_should_deactivate == "yes"
+
+	if !bool_should_deactivate {
+		logrus.Debugf ("shouldDeactivate: string_should_deactivate = %s", string_should_deactivate)
+	}
+
+	return bool_should_deactivate, nil
+}
+
+func (r *reconciler) nameWeHandle (name string) (bool, error) {
+	if should, err := r.shouldDeactivate (); err != nil {
+		return false, err
+	} else if should {
+		logrus.Debugf ("nameWeHandle: shouldDeactivate!")
+		return false, nil
+	}
+	if strings.HasPrefix(name, "libvirt-ppc64le-") {
+		return true, nil
+	} else if strings.HasPrefix(name, "libvirt-s390x-") {
+		return true, nil
+	} else {
+		return false, nil
+	}
+}
+
+func (r *reconciler) reconcile(log *logrus.Entry, request reconcile.Request) error {
+	resourceObject := &crds.ResourceObject{}
+	if err := r.client.Get(r.ctx, request.NamespacedName, resourceObject); err != nil {
+		if kerrors.IsNotFound(err) {
+			return nil
+		}
+		return fmt.Errorf("failed to get object %s: %v", request.NamespacedName.String(), err)
+	}
+
+	if resourceObject.Status.State == common.ToBeDeleted {
+		if weHandle, err := r.nameWeHandle(resourceObject.Name); err != nil {
+			return err
+		} else if weHandle {
+			if found, err:= Cleanup (resourceObject.Name); err != nil {
+				return err
+			} else if found {
+				return fmt.Errorf("reconcile: libvirt cleanup still has uncleaned resources")
+			} else {
+				resourceObject.Status.State = common.Tombstone
+				return nil
+			}
+		}
+	}
+
+	// We only care about unowned resources in ToBeDeleted state
+	if resourceObject.Status.Owner != "" || resourceObject.Status.State != common.ToBeDeleted {
+		return nil
+	}
+
+	isDynamic, err := r.isResourceDynamic(resourceObject)
+	if err != nil {
+		return fmt.Errorf("failed to check if resource is dynamic: %v", err)
+	}
+	if !isDynamic {
+		return nil
+	}
+
+	commonResourceObject := resourceObject.ToResource()
+	cleaner.RecycleOne(r.boskosClient, &commonResourceObject)
+
+	resourceObject.Status.State = common.Tombstone
+	if err := r.client.Update(r.ctx, resourceObject); err != nil {
+		return fmt.Errorf("failed to update object after setting status to tombstone: %v", err)
+	}
+	log.WithField("new-state", common.Tombstone).Debug("Successfully updated objects state.")
+
+	return nil
+}
+
+func (r *reconciler) isResourceDynamic(resourceObject *crds.ResourceObject) (bool, error) {
+	drlcName := types.NamespacedName{Namespace: r.namespace, Name: resourceObject.Spec.Type}
+	err := r.client.Get(r.ctx, drlcName, &crds.DRLCObject{})
+	return !kerrors.IsNotFound(err), ctrlruntimeclient.IgnoreNotFound(err)
+}

--- a/cmd/libvirt-cleaner/libvirt-cleaner.go
+++ b/cmd/libvirt-cleaner/libvirt-cleaner.go
@@ -1,0 +1,196 @@
+/*
+Copyright 2020 The Kubernetes Authors.
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+    http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package main
+
+import (
+	"bytes"
+	"errors"
+	"fmt"
+	"github.com/sirupsen/logrus"
+	"io"
+	"os/exec"
+	"strings"
+)
+
+func virsh (connect string, command string, grep_arg string) ([]string, error) {
+	var b bytes.Buffer
+	var err error
+
+	logrus.Debugf("virsh -c %s %s --all --name | grep %s", connect, command, grep_arg)
+
+	c1 := exec.Command("mock-nss.sh", "virsh", "-c", connect, command, "--all", "--name")
+	c2 := exec.Command("grep", grep_arg)
+	r, w := io.Pipe() 
+	c1.Stdout = w
+	c2.Stdin = r
+	c2.Stdout = &b
+	err = c1.Start()
+	if err != nil {
+		logrus.Infof("virsh c1.Start(): %s", err)
+		return []string{""}, err
+	}
+	err = c2.Start()
+	if err != nil {
+		logrus.Infof("virsh c2.Start(): %s", err)
+		return []string{""}, err
+	}
+	err = c1.Wait()
+	if err != nil {
+		logrus.Infof("virsh c1.Wait(): %s", err)
+		return []string{""}, err
+	}
+	err = w.Close()
+	if err != nil {
+		logrus.Infof("virsh w.Close(): %s", err)
+		return []string{""}, err
+	}
+	err = c2.Wait()
+	if err != nil {
+		logrus.Infof("virsh c2.Wait(): %s", err)
+		return []string{""}, err
+	}
+	logrus.Infof("virsh %s output:\n%s", command, &b)
+
+	return strings.Split(strings.TrimSuffix(b.String(), "\n"), "\n"), nil
+}
+
+func get_domain (resource string) (string, error) {
+
+	if strings.HasPrefix(resource, "libvirt-ppc64le-0-") {			// C155F2U33
+		return "sshd-0.bastion-ppc64le-libvirt.svc.cluster.local", nil
+	} else if strings.HasPrefix(resource, "libvirt-ppc64le-1-") {		// C155F2U31
+		// return "10.10.1.10", nil					// Local testing
+		return "sshd-1.bastion-ppc64le-libvirt.svc.cluster.local", nil
+	} else if strings.HasPrefix(resource, "libvirt-ppc64le-2-") {		// C155F2U35
+		return "sshd-2.bastion-ppc64le-libvirt.svc.cluster.local", nil
+	} else if strings.HasPrefix(resource, "libvirt-s390x-0-") {		// lnxocp01
+		return "sshd-0.bastion-z.svc.cluster.local", nil
+	} else if strings.HasPrefix(resource, "libvirt-s390x-1-") {		// lnxocp02
+		return "sshd-1.bastion-z.svc.cluster.local", nil
+	}
+
+	return "", errors.New(fmt.Sprintf("Unknown domain %s", resource))
+}
+
+func Cleanup (resource string) (bool, error) {
+
+	logrus.Debugf("libvirt_cleaner.Cleanup (%s)", resource)
+
+	domain, err := get_domain (resource)
+	if err != nil {
+		return false, err
+	}
+
+	connect := fmt.Sprintf("qemu+tcp://%s/system", domain)
+
+	result, err := virsh (connect, "list", resource)
+	if err != nil {
+		return false, errors.New(fmt.Sprintf("virsh list %s: %v", resource, err))
+	}
+	logrus.Infof("executing virsh list %s: output: %q", resource, result)
+
+	for _, domain := range result {
+		logrus.Infof("executing virsh -c %s destroy %s", connect, domain)
+		c1 := exec.Command("mock-nss.sh", "virsh", "-c", connect, "destroy", domain)
+		o1, err1 := c1.CombinedOutput()
+		if err != nil {
+			return false, errors.New(fmt.Sprintf("virsh destroy %s %v", domain, err1))
+		}
+		logrus.Infof("c1 output: %s", o1)
+
+		logrus.Infof("executing virsh -c %s undefine %s", connect, domain)
+		c2 := exec.Command("mock-nss.sh", "virsh", "-c", connect, "undefine", domain)
+		o2, err2 := c2.CombinedOutput()
+		if err != nil {
+			return false, errors.New(fmt.Sprintf("virsh undefine %s %v", domain, err2))
+		}
+		logrus.Infof("c2 output: %s", o2)
+	}
+
+	result, err = virsh (connect, "pool-list", resource)
+	if err != nil {
+		return false, errors.New(fmt.Sprintf("virsh pool-list %s: %v", resource, err))
+	}
+	logrus.Infof("executing virsh pool-list %s: output: %q", resource, result)
+
+	for _, domain := range result {
+		logrus.Infof("executing virsh -c %s pool-list %s", connect, domain)
+		c1 := exec.Command("mock-nss.sh", "virsh", "-c", connect, "pool-destroy", domain)
+		o1, err1 := c1.CombinedOutput()
+		if err1 != nil {
+			return false, errors.New(fmt.Sprintf("virsh pool-destroy %s %v", domain, err1))
+		}
+		logrus.Infof("c1 output: %s", o1)
+
+		logrus.Infof("executing virsh -c %s pool-undefine %s", connect, domain)
+		c2 := exec.Command("mock-nss.sh", "virsh", "-c", connect, "pool-undefine", domain)
+		o2, err2 := c2.CombinedOutput()
+		if err2 != nil {
+			return false, errors.New(fmt.Sprintf("virsh pool-undefine %s %v", domain, err2))
+		}
+		logrus.Infof("c2 output: %s", o2)
+	}
+
+	result, err = virsh (connect, "net-list", resource)
+	if err != nil {
+		return false, errors.New(fmt.Sprintf("virsh net-list %s: %v", resource, err))
+	}
+	logrus.Infof("executing virsh net-list %s: output: %q", resource, result)
+
+	for _, domain := range result {
+		logrus.Infof("executing virsh -c %s net-destroy %s", connect, domain)
+		c1 := exec.Command("mock-nss.sh", "virsh", "-c", connect, "net-destroy", domain)
+		o1, err1 := c1.CombinedOutput()
+		if err1 != nil {
+			return false, errors.New(fmt.Sprintf("virsh net-destroy %s %v", domain, err1))
+		}
+		logrus.Infof("c1 output: %s", o1)
+
+		logrus.Infof("executing virsh -c %s net-undefine %s", connect, domain)
+		c2 := exec.Command("mock-nss.sh", "virsh", "-c", connect, "net-undefine", domain)
+		o2, err2 := c2.CombinedOutput()
+		if err2 != nil {
+			return false, errors.New(fmt.Sprintf("virsh net-undefine %s %v", domain, err2))
+		}
+		logrus.Infof("c2 output: %s", o2)
+	}
+
+	var found = false
+
+	result, err = virsh (connect, "list", resource)
+	if (err == nil) && (len(result) >= 1) && (result[0] != "") {
+		logrus.Infof("re-executing virsh list %s: output: %q", resource, result)
+		found = true
+	}
+
+	result, err = virsh (connect, "pool-list", resource)
+	if (err == nil) && (len(result) >= 1) && (result[0] != "") {
+		logrus.Infof("re-executing virsh pool-list %s: output: %q", resource, result)
+		found = true
+	}
+
+	result, err = virsh (connect, "net-list", resource)
+	if (err == nil) && (len(result) >= 1) && (result[0] != "") {
+		logrus.Infof("re-executing virsh net-list %s: output: %q", resource, result)
+		found = true
+	}
+
+	if found {
+		logrus.Debugf("libvirt_cleaner.Cleanup: ERROR: Failed to clean up the resource %s", resource)
+	} else {
+		logrus.Debugf("libvirt_cleaner.Cleanup: SUCCESS: Cleaned up the resource %s", resource)
+	}
+
+	return found, nil
+}

--- a/cmd/libvirt-cleaner/main.go
+++ b/cmd/libvirt-cleaner/main.go
@@ -1,0 +1,132 @@
+/*
+Copyright 2019 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package main
+
+import (
+	"flag"
+	"fmt"
+	"time"
+
+	"github.com/sirupsen/logrus"
+	corev1 "k8s.io/api/core/v1"
+	"sigs.k8s.io/controller-runtime/pkg/manager"
+
+	"k8s.io/test-infra/pkg/flagutil"
+	"k8s.io/test-infra/prow/config"
+	prowflagutil "k8s.io/test-infra/prow/flagutil"
+	"k8s.io/test-infra/prow/interrupts"
+	"k8s.io/test-infra/prow/logrusutil"
+	prowmetrics "k8s.io/test-infra/prow/metrics"
+	"k8s.io/test-infra/prow/pjutil/pprof"
+	"sigs.k8s.io/boskos/client"
+	"sigs.k8s.io/boskos/crds"
+
+	"github.com/bombsimon/logrusr"
+	controllerruntime "sigs.k8s.io/controller-runtime"
+)
+
+const (
+	defaultCleanerCount      = 15
+	defaultBoskosRetryPeriod = 15 * time.Second
+	defaultOwner             = "libvirt-cleaner"
+)
+
+var (
+	kubeClientOptions      crds.KubernetesClientOptions
+	instrumentationOptions prowflagutil.InstrumentationOptions
+
+	boskosURL           string
+	username            string
+	passwordFile        string
+	namespace           string
+	cleanerCount        int
+	logLevel            string
+	useV2Implementation bool
+)
+
+func init() {
+	flag.StringVar(&boskosURL, "boskos-url", "http://boskos", "Boskos Server URL")
+	flag.StringVar(&username, "username", "", "Username used to access the Boskos server")
+	flag.StringVar(&passwordFile, "password-file", "", "The path to password file used to access the Boskos server")
+	flag.IntVar(&cleanerCount, "cleaner-count", defaultCleanerCount, "Number of threads running cleanup")
+	flag.StringVar(&namespace, "namespace", corev1.NamespaceDefault, "namespace to install on")
+	flag.StringVar(&logLevel, "log-level", "info", fmt.Sprintf("Log level is one of %v.", logrus.AllLevels))
+	flag.BoolVar(&useV2Implementation, "use-v2-implementation", false, "Use the new controller-based v2 implementation. It is much faster and works directly based on the crds, but was used less")
+}
+
+func main() {
+	logrusutil.ComponentInit()
+	controllerruntime.SetLogger(logrusr.NewLogger(logrus.StandardLogger()))
+	for _, o := range []flagutil.OptionGroup{&kubeClientOptions, &instrumentationOptions} {
+		o.AddFlags(flag.CommandLine)
+	}
+	flag.Parse()
+
+	level, err := logrus.ParseLevel(logLevel)
+	if err != nil {
+		logrus.WithError(err).Fatal("invalid log level specified")
+	}
+	logrus.SetLevel(level)
+	for _, o := range []flagutil.OptionGroup{&kubeClientOptions, &instrumentationOptions} {
+		if err := o.Validate(false); err != nil {
+			logrus.Fatalf("Invalid options: %v", err)
+		}
+	}
+
+	client, err := client.NewClient(defaultOwner, boskosURL, username, passwordFile)
+	if err != nil {
+		logrus.WithError(err).Fatal("unable to create a Boskos client")
+	}
+
+	defer interrupts.WaitForGracefulShutdown()
+	prowmetrics.ExposeMetrics("boskos", config.PushGateway{}, instrumentationOptions.MetricsPort)
+	pprof.Instrument(instrumentationOptions)
+
+	if useV2Implementation {
+		v2Main(client)
+	} else {
+		logrus.Fatalf("v1Main not supported")
+	}
+}
+
+func v2Main(client *client.Client) {
+	cfg, err := kubeClientOptions.Cfg()
+	if err != nil {
+		logrus.WithError(err).Fatal("failed to get kubeconfig.")
+	}
+
+	mgr, err := manager.New(cfg, manager.Options{
+		LeaderElection:          true,
+		LeaderElectionNamespace: namespace,
+		LeaderElectionID:        "boskos-libvirt-cleaner-leaderlock",
+		Namespace:               namespace,
+		MetricsBindAddress:      "0",
+	})
+	if err != nil {
+		logrus.WithError(err).Fatal("failed to construct manager.")
+	}
+
+	if err := Add(mgr, client, namespace); err != nil {
+		logrus.WithError(err).Fatal("failed to add controller to manager.")
+	}
+
+	if err := mgr.Start(interrupts.Context()); err != nil {
+		logrus.WithError(err).Fatal("manager failed")
+	} else {
+		logrus.Info("manager ended gracefully.")
+	}
+}

--- a/crds/client.go
+++ b/crds/client.go
@@ -51,7 +51,16 @@ type KubernetesClientOptions struct {
 // AddFlags adds kube client flags to existing FlagSet.
 func (o *KubernetesClientOptions) AddFlags(fs *flag.FlagSet) {
 	fs.StringVar(&o.projectedTokenFile, "projected-token-file", "", "A projected serviceaccount token file. If set, this will be configured as token file in the in-cluster config.")
-	fs.StringVar(&o.kubeConfig, "kubeconfig", "", "absolute path to the kubeConfig file")
+	kubeconfigFlagDescription := "absolute path to the kubeconfig file"
+	if f := flag.Lookup("kubeconfig"); f != nil {
+		logrus.Infof("HAMZY: kubeconfig1 %v ", f)
+		f.Usage = kubeconfigFlagDescription
+		// https://i.kym-cdn.com/entries/icons/original/000/018/012/this_is_fine.jpeg
+		defer func() { o.kubeConfig = f.Value.String() }()
+		} else {
+		logrus.Infof("HAMZY: kubeconfig2 %v ", f)
+		fs.StringVar(&o.kubeConfig, "kubeconfig", "", "absolute path to the kubeConfig file")
+	}
 	fs.BoolVar(&o.inMemory, "in_memory", false, "Use in memory client instead of CRD")
 }
 

--- a/go.mod
+++ b/go.mod
@@ -11,6 +11,7 @@ replace (
 
 require (
 	github.com/aws/aws-sdk-go v1.37.22
+	github.com/bombsimon/logrusr v1.1.0 // indirect
 	github.com/fsnotify/fsnotify v1.4.9
 	github.com/go-test/deep v1.0.7
 	github.com/google/go-cmp v0.5.5

--- a/go.sum
+++ b/go.sum
@@ -241,6 +241,8 @@ github.com/blang/semver v3.5.0+incompatible/go.mod h1:kRBLl5iJ+tD4TcOOxsy/0fnweb
 github.com/blang/semver v3.5.1+incompatible/go.mod h1:kRBLl5iJ+tD4TcOOxsy/0fnwebNt5EWlYSAyrTnjyyk=
 github.com/bmizerany/assert v0.0.0-20160611221934-b7ed37b82869/go.mod h1:Ekp36dRnpXw/yCqJaO+ZrUyxD+3VXMFFr56k5XYrpB4=
 github.com/bmizerany/perks v0.0.0-20141205001514-d9a9656a3a4b/go.mod h1:ac9efd0D1fsDb3EJvhqgXRbFx7bs2wqZ10HQPeU8U/Q=
+github.com/bombsimon/logrusr v1.1.0 h1:Y03FI4Z/Shyrc9jF26vuaUbnPxC5NMJnTtJA/3Lihq8=
+github.com/bombsimon/logrusr v1.1.0/go.mod h1:Jq0nHtvxabKE5EMwAAdgTaz7dfWE8C4i11NOltxGQpc=
 github.com/bombsimon/wsl/v2 v2.0.0/go.mod h1:mf25kr/SqFEPhhcxW1+7pxzGlW+hIl/hYTKY95VwV8U=
 github.com/bombsimon/wsl/v2 v2.2.0/go.mod h1:Azh8c3XGEJl9LyX0/sFC+CKMc7Ssgua0g+6abzXN4Pg=
 github.com/bombsimon/wsl/v3 v3.0.0/go.mod h1:st10JtZYLE4D5sC7b8xV4zTKZwAQjCH/Hy2Pm1FNZIc=
@@ -1532,6 +1534,7 @@ golang.org/x/sys v0.0.0-20200106162015-b016eb3dc98e/go.mod h1:h1NjWce9XRLGQEsW7w
 golang.org/x/sys v0.0.0-20200113162924-86b910548bc1/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20200116001909-b77594299b42/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20200122134326-e047566fdf82/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
+golang.org/x/sys v0.0.0-20200124204421-9fbb57f87de9/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20200202164722-d101bd2416d5/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20200212091648-12a6c2dcc1e4/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20200223170610-d5e6a3e2c0ae/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=

--- a/images/libvirt-cleaner/Dockerfile
+++ b/images/libvirt-cleaner/Dockerfile
@@ -1,0 +1,49 @@
+# Copyright 2020 The Kubernetes Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Most of the images can be based on distroless, which is fairly lightweight.
+
+ARG go_version
+
+FROM golang:${go_version} as build
+WORKDIR /go/src/app
+
+#FROM registry.ci.openshift.org/ocp/builder:rhel-8-golang-1.15-openshift-4.8 AS builder
+
+# Cache module downloads
+COPY go.mod go.mod
+COPY go.sum go.sum
+RUN go mod download
+
+COPY . .
+
+ARG DOCKER_TAG
+ENV DOCKER_TAG=${DOCKER_TAG}
+
+# Cache build output too
+RUN make build
+
+ARG cmd
+RUN make "${cmd}"
+
+FROM fedora:34
+RUN dnf install -y libvirt-client nss_wrapper
+
+ARG cmd
+COPY --from=build "/go/src/app/_output/bin/${cmd}" /app
+
+#COPY --from=builder /go/src/github.com/openshift/installer/images/libvirt/mock-nss.sh /bin/mock-nss.sh
+RUN curl --output /bin/mock-nss.sh https://raw.githubusercontent.com/openshift/installer/master/images/libvirt/mock-nss.sh && chmod ugo+x /bin/mock-nss.sh
+
+ENTRYPOINT ["/app"]


### PR DESCRIPTION
This adds a cleaner for CIs using a libvirt deployment.  After a job has
run, cleanup of libvirt resources needs to be enforced before another
libvirt deployment can happen.