### PR TITLE
Boskos: Allow HA by adding optional leader election

### DIFF
--- a/cmd/boskos/boskos.go
+++ b/cmd/boskos/boskos.go
@@ -29,10 +29,14 @@ import (
 	"github.com/sirupsen/logrus"
 	"github.com/spf13/viper"
 	corev1 "k8s.io/api/core/v1"
+	toolsleaderelection "k8s.io/client-go/tools/leaderelection"
+	"k8s.io/client-go/tools/leaderelection/resourcelock"
+	"k8s.io/client-go/tools/record"
 	ctrlruntimeclient "sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/controller"
 	"sigs.k8s.io/controller-runtime/pkg/event"
 	"sigs.k8s.io/controller-runtime/pkg/handler"
+	"sigs.k8s.io/controller-runtime/pkg/leaderelection"
 	"sigs.k8s.io/controller-runtime/pkg/manager"
 	"sigs.k8s.io/controller-runtime/pkg/predicate"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
@@ -64,10 +68,12 @@ var (
 	configPath = flag.String("config", "config.yaml", "Path to init resource file")
 	_          = flag.Duration("dynamic-resource-update-period", defaultDynamicResourceUpdatePeriod,
 		"Legacy flag that does nothing but is kept for compatibility reasons")
-	requestTTL = flag.Duration("request-ttl", defaultRequestTTL, "request TTL before losing priority in the queue")
-	logLevel   = flag.String("log-level", "info", fmt.Sprintf("Log level is one of %v.", logrus.AllLevels))
-	namespace  = flag.String("namespace", corev1.NamespaceDefault, "namespace to install on")
-	port       = flag.Int("port", 8080, "Port to serve on")
+	requestTTL              = flag.Duration("request-ttl", defaultRequestTTL, "request TTL before losing priority in the queue")
+	logLevel                = flag.String("log-level", "info", fmt.Sprintf("Log level is one of %v.", logrus.AllLevels))
+	namespace               = flag.String("namespace", corev1.NamespaceDefault, "namespace to install on")
+	port                    = flag.Int("port", 8080, "Port to serve on")
+	enableLeaderElection    = flag.Bool("enable-leader-election", false, "If leader election should be enabled. If enabled, it is possible to run Boskos with multiple replicas and only the one that is leader will receive traffic.")
+	leaderElectionNamespace = flag.String("leader-election-namespace", "", "Namespace to use for leader election. If running in-cluster, this defaults to the pods namespace")
 
 	httpRequestDuration = prowmetrics.HttpRequestDuration("boskos", 0.005, 1200)
 	httpResponseSize    = prowmetrics.HttpResponseSize("boskos", 128, 65536)
@@ -115,6 +121,46 @@ func main() {
 	mgr, err := kubeClientOptions.Manager(*namespace, &crds.ResourceObject{}, &crds.DRLCObject{})
 	if err != nil {
 		logrus.WithError(err).Fatal("Failed to get mgr")
+	}
+
+	if *enableLeaderElection {
+		cfg, err := kubeClientOptions.Cfg()
+		if err != nil {
+			logrus.WithError(err).Fatal("Failed to get kubeconfig")
+		}
+		lock, err := leaderelection.NewResourceLock(cfg, loggingFakeEventRecorderProvider(), leaderelection.Options{
+			LeaderElection:             true,
+			LeaderElectionResourceLock: resourcelock.LeasesResourceLock,
+			LeaderElectionNamespace:    *leaderElectionNamespace,
+			LeaderElectionID:           "boskos-server"},
+		)
+		if err != nil {
+			logrus.WithError(err).Fatal("Failed to construct leader election lock")
+		}
+
+		elected := make(chan struct{})
+		elector, err := toolsleaderelection.NewLeaderElector(toolsleaderelection.LeaderElectionConfig{
+			Lock:          lock,
+			LeaseDuration: 15 * time.Second,
+			RenewDeadline: 10 * time.Second,
+			RetryPeriod:   2 * time.Second,
+			Callbacks: toolsleaderelection.LeaderCallbacks{
+				OnStartedLeading: func(_ context.Context) { close(elected) },
+				OnStoppedLeading: func() { logrus.Fatal("Lost leaderelection") },
+			},
+			ReleaseOnCancel: true,
+		})
+		if err != nil {
+			logrus.WithError(err).Fatal("failed to construct leader elector")
+		}
+
+		go func() {
+			elector.Run(interrupts.Context())
+		}()
+
+		logrus.Info("Waiting to be elected leader")
+		<-elected
+		logrus.Info("Got elected to leader, starting")
 	}
 
 	storage := ranch.NewStorage(interrupts.Context(), mgr.GetClient(), *namespace)
@@ -231,4 +277,23 @@ func resourceUpdatePredicate() predicate.Predicate {
 		},
 		GenericFunc: func(_ event.GenericEvent) bool { return true },
 	}
+}
+
+type recorderProvider struct {
+	recorder record.EventRecorder
+}
+
+func (rp *recorderProvider) GetEventRecorderFor(_ string) record.EventRecorder {
+	return rp.recorder
+}
+
+func loggingFakeEventRecorderProvider() *recorderProvider {
+	events := make(chan string)
+	go func() {
+		for event := range events {
+			logrus.WithField("event", event).Info("Received event for leader election recorder")
+		}
+	}()
+
+	return &recorderProvider{recorder: &record.FakeRecorder{Events: events}}
 }

--- a/crds/client.go
+++ b/crds/client.go
@@ -97,7 +97,6 @@ func (o *KubernetesClientOptions) Manager(namespace string, startCacheFor ...ctr
 			EventBroadcaster: record.NewBroadcasterForTests(time.Hour),
 		})
 	}
-	// func(cache cache.Cache, config *rest.Config, options client.Options, uncachedObjects ...client.Object) (client.Client, error)
 
 	cfg, err := o.Cfg()
 	if err != nil {

--- a/deployments/base/rbac.yaml
+++ b/deployments/base/rbac.yaml
@@ -21,17 +21,32 @@ metadata:
 kind: Role
 apiVersion: rbac.authorization.k8s.io/v1
 metadata:
-  name: boskos-crd-admin
+  name: boskos-server
   namespace: boskos
 rules:
   - apiGroups: ["boskos.k8s.io"]
     resources: ["*"]
     verbs: ["*"]
+  - apiGroups:
+    - coordination.k8s.io
+    resources:
+    - leases
+    resourceNames:
+    - boskos-server
+    verbs:
+    - get
+    - update
+  - apiGroups:
+    - coordination.k8s.io
+    resources:
+    - leases
+    verbs:
+    - create
 ---
 kind: RoleBinding
 apiVersion: rbac.authorization.k8s.io/v1
 metadata:
-  name: boskos-crd-admin
+  name: boskos-server
   namespace: boskos
 subjects:
   - kind: ServiceAccount


### PR DESCRIPTION
This change optionally makes the Boskos server use leader election. This
allows to have multiple replicas running of which only one is active in
order to reduce downtime when one replica gets unavailable.