### PR TITLE
Boskos: Manage a label that denotes leader to allow HA setups

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -24,3 +24,9 @@ linters:
     - varcheck
     - whitespace
   fast: false
+
+issues:
+  exclude-rules:
+  - linters:
+    - staticcheck
+    text: "SA1019: fakectrlruntimeclient.NewFakeClient is deprecated:"

--- a/crds/client.go
+++ b/crds/client.go
@@ -82,7 +82,7 @@ func (o *KubernetesClientOptions) Client() (ctrlruntimeclient.Client, error) {
 // Manager returns a Manager. It contains a client whose Reader is cache backed. Namespace can be empty
 // in which case the client will use all namespaces.
 // It blocks until the cache was synced for all types passed in startCacheFor.
-func (o *KubernetesClientOptions) Manager(namespace string, startCacheFor ...ctrlruntimeclient.Object) (manager.Manager, error) {
+func (o *KubernetesClientOptions) Manager(namespace string, enableLeaderElection bool, startCacheFor ...ctrlruntimeclient.Object) (manager.Manager, error) {
 	if o.inMemory {
 		return manager.New(&rest.Config{}, manager.Options{
 			LeaderElection:     false,
@@ -106,9 +106,12 @@ func (o *KubernetesClientOptions) Manager(namespace string, startCacheFor ...ctr
 	cfg.Burst = 200
 
 	mgr, err := manager.New(cfg, manager.Options{
-		LeaderElection:     false,
-		Namespace:          namespace,
-		MetricsBindAddress: "0",
+		LeaderElection:                enableLeaderElection,
+		LeaderElectionReleaseOnCancel: true,
+		LeaderElectionResourceLock:    "leases",
+		LeaderElectionID:              "boskos-server",
+		Namespace:                     namespace,
+		MetricsBindAddress:            "0",
 	})
 	if err != nil {
 		return nil, fmt.Errorf("failed to construct manager: %v", err)

--- a/deployments/base/deployment.yaml
+++ b/deployments/base/deployment.yaml
@@ -18,7 +18,7 @@ metadata:
   name: boskos
   namespace: boskos
 spec:
-  replicas: 1
+  replicas: 3
   selector:
     matchLabels:
       app: boskos
@@ -35,14 +35,25 @@ spec:
           args:
             - --config=/etc/config/boskos-resources.yaml
             - --namespace=$(NAMESPACE)
+            - --pod-name=$(POD_NAME)
+            - --boskos-label-selector=app=boskos
+            - --enable-leader-election=true
           env:
             - name: NAMESPACE
               valueFrom:
                 fieldRef:
                   fieldPath: metadata.namespace
+            - name: POD_NAME
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.name
           ports:
             - containerPort: 8080
               protocol: TCP
+          readinessProbe:
+            httpGet:
+              path: /healthz/ready
+              port: 8081
           volumeMounts:
             - name: boskos-config
               mountPath: /etc/config

--- a/deployments/base/rbac.yaml
+++ b/deployments/base/rbac.yaml
@@ -28,6 +28,15 @@ rules:
     resources: ["*"]
     verbs: ["*"]
   - apiGroups:
+    - ""
+    resources:
+    - pods
+    verbs:
+    - get
+    - list
+    - watch
+    - update
+  - apiGroups:
     - coordination.k8s.io
     resources:
     - leases
@@ -54,7 +63,7 @@ subjects:
     namespace: boskos
 roleRef:
   kind: Role
-  name: boskos-crd-admin
+  name: boskos-server
   apiGroup: rbac.authorization.k8s.io
 ---
 kind: Role

--- a/deployments/base/service.yaml
+++ b/deployments/base/service.yaml
@@ -20,7 +20,7 @@ metadata:
   namespace: boskos
 spec:
   selector:
-    app: boskos
+    boskos-leader: "true"
   ports:
     - name: default
       protocol: TCP

--- a/leaderlabelreconciler/leaderlabelreconciler.go
+++ b/leaderlabelreconciler/leaderlabelreconciler.go
@@ -1,0 +1,95 @@
+/*
+Copyright 2020 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package leaderlabelreconciler
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/sirupsen/logrus"
+	corev1 "k8s.io/api/core/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/labels"
+	"sigs.k8s.io/controller-runtime/pkg/builder"
+	ctrlruntimeclient "sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/controller"
+	"sigs.k8s.io/controller-runtime/pkg/manager"
+	"sigs.k8s.io/controller-runtime/pkg/predicate"
+	"sigs.k8s.io/controller-runtime/pkg/reconcile"
+)
+
+func AddToManager(mgr manager.Manager, podLabelSelector labels.Selector, leaderLabelKey string, leaderPodName string) error {
+	return builder.ControllerManagedBy(mgr).
+		For(
+			&corev1.Pod{},
+			builder.WithPredicates(predicate.NewPredicateFuncs(func(o ctrlruntimeclient.Object) bool {
+				return podLabelSelector.Matches(labels.Set(o.GetLabels()))
+			}))).
+		WithOptions(controller.Options{MaxConcurrentReconciles: 10}).
+		Complete(&reconciler{
+			client:         mgr.GetClient(),
+			leaderLabelKey: leaderLabelKey,
+			leaderPodName:  leaderPodName,
+		})
+}
+
+type reconciler struct {
+	client         ctrlruntimeclient.Client
+	leaderLabelKey string
+	leaderPodName  string
+}
+
+const leaderLabelValue = "true"
+
+func (r *reconciler) Reconcile(ctx context.Context, req reconcile.Request) (_ reconcile.Result, e error) {
+	log := logrus.WithField("request", req.String())
+	var pod corev1.Pod
+	if err := r.client.Get(ctx, req.NamespacedName, &pod); err != nil {
+		if apierrors.IsNotFound(err) {
+			return reconcile.Result{}, nil
+		}
+		return reconcile.Result{}, fmt.Errorf("failed to get pod %s: %w", req, err)
+	}
+
+	if pod.Name == r.leaderPodName && pod.DeletionTimestamp == nil {
+		if pod.Labels[r.leaderLabelKey] == leaderLabelValue {
+			return reconcile.Result{}, nil
+		}
+		if pod.Labels == nil {
+			pod.Labels = map[string]string{}
+		}
+		pod.Labels[r.leaderLabelKey] = leaderLabelValue
+		if err := r.client.Update(ctx, &pod); err != nil {
+			return reconcile.Result{}, fmt.Errorf("failed to update leader pod %s: %w", pod.Name, err)
+		}
+
+		log.Info("Set leader label on pod")
+		return reconcile.Result{}, nil
+	}
+
+	if pod.Labels[r.leaderLabelKey] != leaderLabelValue {
+		return reconcile.Result{}, nil
+	}
+
+	delete(pod.Labels, r.leaderLabelKey)
+	if err := r.client.Update(ctx, &pod); err != nil {
+		return reconcile.Result{}, fmt.Errorf("failed to update non-leader pod %s: %w", pod.Name, err)
+	}
+	log.Info("Removed leader label on pod")
+
+	return reconcile.Result{}, nil
+}

--- a/leaderlabelreconciler/leaderlabelreconciler_test.go
+++ b/leaderlabelreconciler/leaderlabelreconciler_test.go
@@ -1,0 +1,74 @@
+/*
+Copyright 2020 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package leaderlabelreconciler
+
+import (
+	"context"
+	"testing"
+
+	"github.com/google/go-cmp/cmp"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+	fakectrlruntimeclient "sigs.k8s.io/controller-runtime/pkg/client/fake"
+	"sigs.k8s.io/controller-runtime/pkg/reconcile"
+)
+
+func TestReconcile(t *testing.T) {
+	const leaderLabelKey = "leader"
+	testCases := []struct {
+		name              string
+		pod               *corev1.Pod
+		expectedPodLabels map[string]string
+	}{
+		{
+			name: "Label is added",
+			pod: &corev1.Pod{ObjectMeta: metav1.ObjectMeta{
+				Name: "leader",
+			}},
+			expectedPodLabels: map[string]string{leaderLabelKey: "true"},
+		},
+		{
+			name: "Label is removed",
+			pod: &corev1.Pod{ObjectMeta: metav1.ObjectMeta{
+				Name:   "not-leader",
+				Labels: map[string]string{leaderLabelKey: "true"}},
+			},
+		},
+	}
+
+	for _, tc := range testCases {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			client := fakectrlruntimeclient.NewFakeClient(tc.pod)
+
+			r := &reconciler{client: client, leaderLabelKey: leaderLabelKey, leaderPodName: "leader"}
+			if _, err := r.Reconcile(context.Background(), reconcile.Request{NamespacedName: types.NamespacedName{Name: tc.pod.Name}}); err != nil {
+				t.Fatalf("reconciliation failed: %v", err)
+			}
+
+			var pod corev1.Pod
+			if err := client.Get(context.Background(), types.NamespacedName{Name: tc.pod.Name}, &pod); err != nil {
+				t.Fatalf("failed to get pod: %v", err)
+			}
+
+			if diff := cmp.Diff(pod.Labels, tc.expectedPodLabels); diff != "" {
+				t.Errorf("actual labels differ from expected labels: %s", diff)
+			}
+		})
+	}
+}


### PR DESCRIPTION
This change adds a small controller to boskos that will make it manage a
label on pods. The label will be set on the pod that has the leader
lease and removed on all other pods. This in turn allows to have
multiple replicas of boskos running by using a service that targets said
label.

It makes the new `--boskos-label-selector` and `--pod-name` flags mandatory when `--enable-leader-election` is set.

Apart from the included unit tests I also manually deployed and tested this with kind:

```
$ k get pod -o wide
NAME                      READY   STATUS    RESTARTS   AGE   IP            NODE                 NOMINATED NODE   READINESS GATES
boskos-5dfb47b97b-gsgcx   1/1     Running   0          18m   10.244.0.26   kind-control-plane   <none>           <none>
boskos-5dfb47b97b-hbcd8   1/1     Running   0          17m   10.244.0.27   kind-control-plane   <none>           <none>
boskos-5dfb47b97b-ppbjv   1/1     Running   0          18m   10.244.0.25   kind-control-plane   <none>           <none>

$ k get endpoints
NAME             ENDPOINTS                                            AGE
boskos           10.244.0.27:8080                                     61m
boskos-metrics   10.244.0.25:9090,10.244.0.26:9090,10.244.0.27:9090   61m
```