### PR TITLE
Update CRDs to apiextensions.k8s.io/v1

### DIFF
--- a/deployments/base/cleaner/deployment.yaml
+++ b/deployments/base/cleaner/deployment.yaml
@@ -33,7 +33,7 @@ spec:
       terminationGracePeriodSeconds: 300
       containers:
         - name: boskos-cleaner
-          image: gcr.io/k8s-staging-boskos/cleaner:v20200617-f289ba6
+          image: gcr.io/k8s-staging-boskos/cleaner:v20211015-2401f5c
           args:
             - --boskos-url=http://boskos
             - --namespace=$(NAMESPACE)

--- a/deployments/base/crd.yaml
+++ b/deployments/base/crd.yaml
@@ -12,10 +12,12 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-apiVersion: apiextensions.k8s.io/v1beta1
+apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   name: dynamicresourcelifecycles.boskos.k8s.io
+  annotations:
+    api-approved.kubernetes.io: https://github.com/kubernetes-sigs/boskos/pull/105
 spec:
   group: boskos.k8s.io
   names:
@@ -24,29 +26,74 @@ spec:
     plural: dynamicresourcelifecycles
     singular: dynamicresourcelifecycle
   scope: Namespaced
-  version: v1
   versions:
     - name: v1
       served: true
       storage: true
-  additionalPrinterColumns:
-    - name: Type
-      type: string
-      description: The dynamic resource type.
-      JSONPath: .spec.config.type
-    - name: Min-Count
-      type: integer
-      description: The minimum count requested.
-      JSONPath: .spec.min-count
-    - name: Max-Count
-      type: integer
-      description: The maximum count requested.
-      JSONPath: .spec.max-count
+      additionalPrinterColumns:
+        - name: Type
+          type: string
+          description: The dynamic resource type.
+          jsonPath: .spec.config.type
+        - name: Min-Count
+          type: integer
+          description: The minimum count requested.
+          jsonPath: .spec.min-count
+        - name: Max-Count
+          type: integer
+          description: The maximum count requested.
+          jsonPath: .spec.max-count
+      schema:
+        openAPIV3Schema:
+          description: Defines the lifecycle of a dynamic resource. All
+            Resource of a given type will be constructed using the same
+            configuration
+          type: object
+          properties:
+            spec:
+              type: object
+              properties:
+                state:
+                  type: string
+                max-count:
+                  description: Maxiumum number of resources expected. This
+                    maximum may be temporarily exceeded while resources are in
+                    the process of being deleted, though this is only expected
+                    when MaxCount is lowered.
+                  type: integer
+                  format: int32
+                min-count:
+                  description: Minimum number of resources to be used as a
+                    buffer. Resources in the process of being deleted and
+                    cleaned up are included in this count.
+                  type: integer
+                  format: int32
+                lifespan:
+                  description: Lifespan of a resource, time after which the
+                    resource should be reset
+                  type: integer
+                  format: int64
+                config:
+                  description: Config information about how to create the
+                    object
+                  type: object
+                  properties:
+                    type:
+                      description: The dynamic resource type
+                      type: string
+                    content:
+                      type: string
+                needs:
+                  description: Define the resource needs to create the object
+                  type: object
+                  x-kubernetes-preserve-unknown-fields: true
 ---
-apiVersion: apiextensions.k8s.io/v1beta1
+apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   name: resources.boskos.k8s.io
+  annotations:
+    api-approved.kubernetes.io: https://github.com/kubernetes-sigs/boskos/pull/105
 spec:
   group: boskos.k8s.io
   names:
@@ -55,24 +102,51 @@ spec:
     plural: resources
     singular: resource
   scope: Namespaced
-  version: v1
   versions:
     - name: v1
       served: true
       storage: true
-  additionalPrinterColumns:
-    - name: Type
-      type: string
-      description: The resource type.
-      JSONPath: .spec.type
-    - name: State
-      type: string
-      description: The current state of the resource.
-      JSONPath: .status.state
-    - name: Owner
-      type: string
-      description: The current owner of the resource.
-      JSONPath: .status.owner
-    - name: Last-Updated
-      type: date
-      JSONPath: .status.lastUpdate
+      additionalPrinterColumns:
+        - name: Type
+          type: string
+          description: The resource type.
+          jsonPath: .spec.type
+        - name: State
+          type: string
+          description: The current state of the resource.
+          jsonPath: .status.state
+        - name: Owner
+          type: string
+          description: The current owner of the resource.
+          jsonPath: .status.owner
+        - name: Last-Updated
+          type: date
+          jsonPath: .status.lastUpdate
+      schema:
+        openAPIV3Schema:
+          description: Abstracts any resource type that can be tracked by boskos
+          type: object
+          properties:
+            spec:
+              description: Holds information that are not likely to change
+              type: object
+              properties:
+                type:
+                  type: string
+            status:
+              description: Holds information that are likely to change
+              type: object
+              properties:
+                state:
+                  type: string
+                owner:
+                  type: string
+                lastUpdate:
+                  type: string
+                  format: date-time
+                userData:
+                  type: object
+                  x-kubernetes-preserve-unknown-fields: true
+                expirationDate:
+                  type: string
+                  format: date-time

--- a/deployments/base/deployment.yaml
+++ b/deployments/base/deployment.yaml
@@ -31,7 +31,7 @@ spec:
       terminationGracePeriodSeconds: 30
       containers:
         - name: boskos
-          image: gcr.io/k8s-staging-boskos/boskos:v20200617-f289ba6
+          image: gcr.io/k8s-staging-boskos/boskos:v20211015-2401f5c
           args:
             - --config=/etc/config/boskos-resources.yaml
             - --namespace=$(NAMESPACE)

--- a/deployments/base/janitor/deployment.yaml
+++ b/deployments/base/janitor/deployment.yaml
@@ -33,7 +33,7 @@ spec:
       serviceAccountName: boskos-janitor
       containers:
         - name: boskos-janitor
-          image: gcr.io/k8s-staging-boskos/janitor:v20200617-f289ba6
+          image: gcr.io/k8s-staging-boskos/janitor:v20211015-2401f5c
           args:
             - --boskos-url=http://boskos
             - --resource-type=$(JANITOR_RESOURCE_TYPES)

--- a/deployments/base/reaper/deployment.yaml
+++ b/deployments/base/reaper/deployment.yaml
@@ -32,7 +32,7 @@ spec:
       terminationGracePeriodSeconds: 30
       containers:
         - name: boskos-reaper
-          image: gcr.io/k8s-staging-boskos/reaper:v20200617-f289ba6
+          image: gcr.io/k8s-staging-boskos/reaper:v20211015-2401f5c
           args:
             - --boskos-url=http://boskos
             - --resource-type=$(REAPER_RESOURCE_TYPES)


### PR DESCRIPTION
Related:
- https://github.com/kubernetes-sigs/boskos/issues/94

These are the changes necessary to bring the CRD definition in line with changes called out in https://kubernetes.io/docs/reference/using-api/deprecation-guide/#customresourcedefinition-v122

WIP because:
- needs upgrade testing

The biggest change here is that the schema is now required. I wrote this
by looking at the types in crd/ and common/. Any field that was a map
got a `x-kubernetes-preserve-unknown-fields: true`

The most controversial change is probably adding the api-approved
annotation, to allow us to keep using the .k8s.io group. This should
mean that updating the CRD doesn't require migrating any of the
resources. As prior art, I'm looking at the fact that prow.k8s.io
did the same thing for its ProwJob CRD.

This is controversial because these CRD's aren't really part of core
kubernetes. They should be moved to the x-k8s.io group. However it's not
immediately clear to me what it would take to have boskos support
transparently migrating resources from CRD's define in one group to
another.

This has been tested by running the example deployment against a kind
cluster running kubernetes 1.22