### PR TITLE
Ignore loading API key

### DIFF
--- a/common/ibmcloud/common.go
+++ b/common/ibmcloud/common.go
@@ -33,7 +33,6 @@ const (
 
 type ResourceData struct {
 	ServiceInstanceID string
-	APIKey            string
 	Region            string
 	Zone              string
 }
@@ -49,11 +48,6 @@ func GetResourceData(r *common.Resource) (*ResourceData, error) {
 		return nil, errors.New("no Service Instance ID in UserData")
 	}
 
-	key, ok := r.UserData.Map.Load(APIKey)
-	if !ok {
-		return nil, errors.New("no API key in UserData")
-	}
-
 	region, ok := r.UserData.Map.Load(Region)
 	if !ok {
 		return nil, errors.New("no region in UserData")
@@ -66,7 +60,6 @@ func GetResourceData(r *common.Resource) (*ResourceData, error) {
 
 	return &ResourceData{
 		ServiceInstanceID: sid.(string),
-		APIKey:            key.(string),
 		Region:            region.(string),
 		Zone:              zone.(string),
 	}, nil

--- a/internal/ibmcloud-janitor/account/account.go
+++ b/internal/ibmcloud-janitor/account/account.go
@@ -30,18 +30,25 @@ const (
 
 // Returns an authenticator for IBM Cloud
 func GetAuthenticator() (core.Authenticator, error) {
+	key, err := GetAPIkeyValue()
+	if err != nil {
+		return nil, errors.New("could not get the value of API key")
+	}
+	auth := &core.IamAuthenticator{
+		ApiKey: key,
+	}
+	return auth, nil
+}
+
+func GetAPIkeyValue() (string, error) {
 	fileName := os.Getenv(APIKeyEnv)
 	if fileName == "" {
-		return nil, errors.New("please set IBMCLOUD_ENV_FILE, it cannot be empty")
+		return "", errors.New("please set IBMCLOUD_ENV_FILE, it cannot be empty")
 	}
 
 	key, err := os.ReadFile(fileName)
 	if err != nil {
-		return nil, err
+		return "", err
 	}
-
-	auth := &core.IamAuthenticator{
-		ApiKey: string(key),
-	}
-	return auth, nil
+	return string(key), nil
 }

--- a/internal/ibmcloud-janitor/resources/powervs_client.go
+++ b/internal/ibmcloud-janitor/resources/powervs_client.go
@@ -76,7 +76,6 @@ func NewPowerVSClient(options *CleanupOptions) (*IBMPowerVSClient, error) {
 
 	pclient.key = &APIKey{
 		serviceIDName: options.Resource.Name,
-		value:         &powervsData.APIKey,
 	}
 
 	auth, err := account.GetAuthenticator()

--- a/internal/ibmcloud-janitor/resources/serviceid.go
+++ b/internal/ibmcloud-janitor/resources/serviceid.go
@@ -29,7 +29,6 @@ import (
 
 type APIKey struct {
 	serviceIDName string
-	value         *string
 }
 
 func getAPIkeyName() string {

--- a/internal/ibmcloud-janitor/resources/serviceid_client.go
+++ b/internal/ibmcloud-janitor/resources/serviceid_client.go
@@ -20,6 +20,8 @@ import (
 	"github.com/IBM/go-sdk-core/v5/core"
 	identityv1 "github.com/IBM/platform-services-go-sdk/iamidentityv1"
 	"github.com/pkg/errors"
+
+	"sigs.k8s.io/boskos/internal/ibmcloud-janitor/account"
 )
 
 type ServiceID struct {
@@ -69,8 +71,13 @@ func NewServiceIDClient(auth core.Authenticator, key *APIKey) (*ServiceID, error
 
 // Returns the account ID
 func (s *ServiceID) GetAccount() (*string, error) {
+	key, err := account.GetAPIkeyValue()
+	if err != nil {
+		return nil, errors.New("could not get the API key value")
+	}
+
 	apikeyDetailsOptions := &identityv1.GetAPIKeysDetailsOptions{
-		IamAPIKey: s.key.value,
+		IamAPIKey: &key,
 	}
 
 	apiKeyDetails, _, err := s.GetAPIKeysDetails(apikeyDetailsOptions)


### PR DESCRIPTION
This PR makes the following changes:

- Does not load the API key as a part of the resource user data
- Uses the Janitor's API key for fetching the account ID

Signed-off-by: Amulyam24 <amulmek1@in.ibm.com>