### PR TITLE
Don't delete AWS IAM roles that have been created too recently

### DIFF
--- a/aws-janitor/resources/iam_roles.go
+++ b/aws-janitor/resources/iam_roles.go
@@ -86,6 +86,10 @@ func (IAMRoles) MarkAndSweep(opts Options, set *Set) error {
 			}
 			l := &iamRole{arn: aws.StringValue(r.Arn), roleID: aws.StringValue(role.RoleId), roleName: aws.StringValue(role.RoleName)}
 			if set.Mark(opts, l, r.CreateDate, tags) {
+				if r.CreateDate != nil && time.Since(*r.CreateDate) < set.ttl {
+					logger.Debugf("%s: created too recently, skipping", l.ARN())
+					continue
+				}
 				if role.RoleLastUsed != nil && role.RoleLastUsed.LastUsedDate != nil && time.Since(*role.RoleLastUsed.LastUsedDate) < set.ttl {
 					logger.Debugf("%s: used too recently, skipping", l.ARN())
 					continue


### PR DESCRIPTION
kOps e2e tests using IAM roles assumed by Pods have been failing randomly due to IAM roles mysteriously disappearing. Since it may take 5-10 minutes between an IAM role being created and the pods consuming a role, there is a window where the AWS janitor can delete unused roles. This PR adds an additional check that the role has not been created too recently before it is removed.