### PR TITLE
Support target groups deletion in aws-janitor repo.

### DIFF
--- a/aws-janitor/resources/list.go
+++ b/aws-janitor/resources/list.go
@@ -39,6 +39,9 @@ type Options struct {
 
 	// Whether to actually delete resources, or just report what would be deleted.
 	DryRun bool
+
+	// If true, clean target groups.
+	EnableTargetGroupClean bool
 }
 
 type Type interface {
@@ -78,6 +81,8 @@ var RegionalTypeList = []Type{
 	Addresses{},
 	ElasticFileSystems{},
 	SQSQueues{},
+	// ELBV2 target groups,
+	TargetGroups{},
 }
 
 // Non-regional AWS resource types, in dependency order

--- a/aws-janitor/resources/target_groups.go
+++ b/aws-janitor/resources/target_groups.go
@@ -1,0 +1,140 @@
+/*
+Copyright 2022 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package resources
+
+import (
+	"fmt"
+	"time"
+
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/service/elbv2"
+	"github.com/pkg/errors"
+	"github.com/sirupsen/logrus"
+	kerrors "k8s.io/apimachinery/pkg/util/errors"
+)
+
+// Clean-up ELBV2 target groups.
+
+type TargetGroups struct{}
+
+func (TargetGroups) MarkAndSweep(opts Options, set *Set) error {
+	logger := logrus.WithField("options", opts)
+	if !opts.EnableTargetGroupClean {
+		logger.Info("Disable target group clean")
+		return nil
+	}
+	svc := elbv2.New(opts.Session, aws.NewConfig().WithRegion(opts.Region))
+	var targetGroups []*targetGroup
+	tgTags := make(map[string]Tags)
+
+	pageFunc := func(page *elbv2.DescribeTargetGroupsOutput, _ bool) bool {
+		for _, tg := range page.TargetGroups {
+			a := &targetGroup{
+				arn: aws.StringValue(tg.TargetGroupArn),
+			}
+			targetGroups = append(targetGroups, a)
+			tgTags[a.ARN()] = nil
+		}
+		return true
+	}
+
+	if err := svc.DescribeTargetGroupsPages(&elbv2.DescribeTargetGroupsInput{}, pageFunc); err != nil {
+		return err
+	}
+
+	fetchTagErr := incrementalFetchTags(tgTags, 20, func(tgArns []*string) error {
+		tagsResp, err := svc.DescribeTags(&elbv2.DescribeTagsInput{ResourceArns: tgArns})
+		if err != nil {
+			return err
+		}
+
+		var errs []error
+		for _, tagDesc := range tagsResp.TagDescriptions {
+			arn := aws.StringValue(tagDesc.ResourceArn)
+			_, ok := tgTags[arn]
+			if !ok {
+				errs = append(errs, fmt.Errorf("unknown target group ARN in tag response: %s", arn))
+				continue
+			}
+			if tgTags[arn] == nil {
+				tgTags[arn] = make(Tags, len(tagDesc.Tags))
+			}
+			for _, t := range tagDesc.Tags {
+				tgTags[arn].Add(t.Key, t.Value)
+			}
+		}
+		return kerrors.NewAggregate(errs)
+	})
+
+	if fetchTagErr != nil {
+		return fetchTagErr
+	}
+
+	for _, tg := range targetGroups {
+		if !set.Mark(opts, tg, nil, tgTags[tg.ARN()]) {
+			continue
+		}
+		logger.Warningf("%s: deleting %T", tg.ARN(), tg)
+
+		if opts.DryRun {
+			continue
+		}
+
+		deleteInput := &elbv2.DeleteTargetGroupInput{
+			TargetGroupArn: aws.String(tg.ARN()),
+		}
+
+		if _, err := svc.DeleteTargetGroup(deleteInput); err != nil {
+			logger.Warningf("%s: delete failed: %v", tg.ARN(), err)
+		}
+	}
+
+	return nil
+}
+
+func (TargetGroups) ListAll(opts Options) (*Set, error) {
+	set := NewSet(0)
+	if !opts.EnableTargetGroupClean {
+		return set, nil
+	}
+	c := elbv2.New(opts.Session, aws.NewConfig().WithRegion(opts.Region))
+	input := &elbv2.DescribeTargetGroupsInput{}
+
+	err := c.DescribeTargetGroupsPages(input, func(tgs *elbv2.DescribeTargetGroupsOutput, isLast bool) bool {
+		now := time.Now()
+		for _, tg := range tgs.TargetGroups {
+			a := &targetGroup{arn: *tg.TargetGroupArn}
+			set.firstSeen[a.ARN()] = now
+		}
+
+		return true
+	})
+
+	return set, errors.Wrapf(err, "couldn't describe target groups for %q in %q", opts.Account, opts.Region)
+}
+
+type targetGroup struct {
+	arn string
+}
+
+func (tg targetGroup) ARN() string {
+	return tg.arn
+}
+
+func (tg targetGroup) ResourceKey() string {
+	return tg.ARN()
+}

--- a/cmd/aws-janitor-boskos/main.go
+++ b/cmd/aws-janitor-boskos/main.go
@@ -43,17 +43,18 @@ import (
 )
 
 var (
-	boskosURL          = flag.String("boskos-url", "http://boskos", "Boskos URL")
-	rTypes             common.CommaSeparatedStrings
-	username           = flag.String("username", "", "Username used to access the Boskos server")
-	passwordFile       = flag.String("password-file", "", "The path to password file used to access the Boskos server")
-	region             = flag.String("region", "", "The region to clean (otherwise defaults to all regions)")
-	sweepCount         = flag.Int("sweep-count", 5, "Number of times to sweep the resources")
-	sweepSleep         = flag.String("sweep-sleep", "30s", "The duration to pause between sweeps")
-	sweepSleepDuration time.Duration
-	logLevel           = flag.String("log-level", "info", fmt.Sprintf("Log level is one of %v.", logrus.AllLevels))
-	dryRun             = flag.Bool("dry-run", false, "If set, don't delete any resources, only log what would be done")
-	ttlTagKey          = flag.String("ttl-tag-key", "", "If set, allow resources to use a tag with this key to override TTL")
+	boskosURL              = flag.String("boskos-url", "http://boskos", "Boskos URL")
+	rTypes                 common.CommaSeparatedStrings
+	username               = flag.String("username", "", "Username used to access the Boskos server")
+	passwordFile           = flag.String("password-file", "", "The path to password file used to access the Boskos server")
+	region                 = flag.String("region", "", "The region to clean (otherwise defaults to all regions)")
+	sweepCount             = flag.Int("sweep-count", 5, "Number of times to sweep the resources")
+	sweepSleep             = flag.String("sweep-sleep", "30s", "The duration to pause between sweeps")
+	sweepSleepDuration     time.Duration
+	logLevel               = flag.String("log-level", "info", fmt.Sprintf("Log level is one of %v.", logrus.AllLevels))
+	dryRun                 = flag.Bool("dry-run", false, "If set, don't delete any resources, only log what would be done")
+	ttlTagKey              = flag.String("ttl-tag-key", "", "If set, allow resources to use a tag with this key to override TTL")
+	enableTargetGroupClean = flag.Bool("enable-target-group-clean", false, "If true, clean target groups.")
 
 	excludeTags common.CommaSeparatedStrings
 	includeTags common.CommaSeparatedStrings
@@ -180,12 +181,13 @@ func cleanResource(res *common.Resource) error {
 		return errors.Wrap(err, "Failed retrieving account")
 	}
 	opts := resources.Options{
-		Session:     s,
-		Account:     acct,
-		DryRun:      *dryRun,
-		ExcludeTags: excludeTM,
-		IncludeTags: includeTM,
-		TTLTagKey:   *ttlTagKey,
+		Session:                s,
+		Account:                acct,
+		DryRun:                 *dryRun,
+		ExcludeTags:            excludeTM,
+		IncludeTags:            includeTM,
+		TTLTagKey:              *ttlTagKey,
+		EnableTargetGroupClean: *enableTargetGroupClean,
 	}
 
 	logrus.WithField("name", res.Name).Info("beginning cleaning")

--- a/cmd/aws-janitor/main.go
+++ b/cmd/aws-janitor/main.go
@@ -40,14 +40,15 @@ import (
 )
 
 var (
-	maxTTL      = flag.Duration("ttl", 24*time.Hour, "Maximum time before attempting to delete a resource. Set to 0s to nuke all non-default resources.")
-	region      = flag.String("region", "", "The region to clean (otherwise defaults to all regions)")
-	path        = flag.String("path", "", "S3 path for mark data (required when -all=false)")
-	cleanAll    = flag.Bool("all", false, "Clean all resources (ignores -path)")
-	logLevel    = flag.String("log-level", "info", fmt.Sprintf("Log level is one of %v.", logrus.AllLevels))
-	dryRun      = flag.Bool("dry-run", false, "If set, don't delete any resources, only log what would be done")
-	ttlTagKey   = flag.String("ttl-tag-key", "", "If set, allow resources to use a tag with this key to override TTL")
-	pushGateway = flag.String("push-gateway", "", "If specified, push prometheus metrics to this endpoint.")
+	maxTTL                 = flag.Duration("ttl", 24*time.Hour, "Maximum time before attempting to delete a resource. Set to 0s to nuke all non-default resources.")
+	region                 = flag.String("region", "", "The region to clean (otherwise defaults to all regions)")
+	path                   = flag.String("path", "", "S3 path for mark data (required when -all=false)")
+	cleanAll               = flag.Bool("all", false, "Clean all resources (ignores -path)")
+	logLevel               = flag.String("log-level", "info", fmt.Sprintf("Log level is one of %v.", logrus.AllLevels))
+	dryRun                 = flag.Bool("dry-run", false, "If set, don't delete any resources, only log what would be done")
+	ttlTagKey              = flag.String("ttl-tag-key", "", "If set, allow resources to use a tag with this key to override TTL")
+	pushGateway            = flag.String("push-gateway", "", "If specified, push prometheus metrics to this endpoint.")
+	enableTargetGroupClean = flag.Bool("enable-target-group-clean", false, "If true, clean target groups.")
 
 	excludeTags common.CommaSeparatedStrings
 	includeTags common.CommaSeparatedStrings
@@ -126,12 +127,13 @@ func main() {
 	}
 
 	opts := resources.Options{
-		Session:     sess,
-		Account:     acct,
-		DryRun:      *dryRun,
-		ExcludeTags: excludeTM,
-		IncludeTags: includeTM,
-		TTLTagKey:   *ttlTagKey,
+		Session:                sess,
+		Account:                acct,
+		DryRun:                 *dryRun,
+		ExcludeTags:            excludeTM,
+		IncludeTags:            includeTM,
+		TTLTagKey:              *ttlTagKey,
+		EnableTargetGroupClean: *enableTargetGroupClean,
 	}
 
 	if *cleanAll {

--- a/cmd/aws-resources-list/main.go
+++ b/cmd/aws-resources-list/main.go
@@ -28,13 +28,14 @@ import (
 )
 
 var (
-	region = flag.String("region", "", "Region to list (defaults to all)")
+	region                 = flag.String("region", "", "Region to list (defaults to all)")
+	enableTargetGroupClean = flag.Bool("enable-target-group-clean", false, "If true, clean target groups.")
 )
 
 func listResources(res resources.Type, sess *session.Session, acct string, regions []string) {
 	fmt.Printf("==%T==\n", res)
 	for _, region := range regions {
-		set, err := res.ListAll(resources.Options{Session: sess, Account: acct, Region: region, DryRun: true})
+		set, err := res.ListAll(resources.Options{Session: sess, Account: acct, Region: region, DryRun: true, EnableTargetGroupClean: *enableTargetGroupClean})
 		if err != nil {
 			fmt.Fprintf(os.Stderr, "error listing %T: %v\n", res, err)
 			continue


### PR DESCRIPTION
For now, the target groups(https://docs.aws.amazon.com/sdk-for-go/api/service/ec2/#TargetGroup) are not GCed by the aws-janitor, this change intends to support that.

TESTED=I run make, make test and make verify locally, not error found.
Tried:
go run cmd/aws-janitor/main.go --dry-run=true --all=true
go run cmd/aws-janitor/main.go --dry-run=true --all=true --enable-target-group-clean=true
locally
The log looks good to me
