### PR TITLE
Bump default golang version used by make targets

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -40,7 +40,7 @@ CONTROLLER_GEN := $(TOOLS_BIN_DIR)/$(CONTROLLER_GEN_BIN)-$(CONTROLLER_GEN_VER)
 
 CMDS = $(notdir $(shell find ./cmd/ -maxdepth 1 -type d | sort))
 
-export GO_VERSION=1.16.6
+export GO_VERSION=1.18.3
 export GO111MODULE=on
 export DOCKER_REPO
 export DOCKER_TAG


### PR DESCRIPTION
This may be the cause for image building breaking after #137 