### PR TITLE
Support vpc endpoints deletion in aws-janitor repo

### DIFF
--- a/aws-janitor/resources/list.go
+++ b/aws-janitor/resources/list.go
@@ -45,6 +45,9 @@ type Options struct {
 
 	// If true, clean key pairs.
 	EnableKeyPairsClean bool
+
+	// If true, clean VPC endpoints.
+	EnableVPCEndpointsClean bool
 }
 
 type Type interface {
@@ -78,6 +81,7 @@ var RegionalTypeList = []Type{
 	RouteTables{},
 	NATGateway{},
 	VPCs{},
+	VPCEndpoints{},
 	DHCPOptions{},
 	Snapshots{},
 	Volumes{},

--- a/aws-janitor/resources/vpc_endpoints.go
+++ b/aws-janitor/resources/vpc_endpoints.go
@@ -1,0 +1,110 @@
+/*
+Copyright 2022 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package resources
+
+import (
+	"fmt"
+	"time"
+
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/service/ec2"
+	"github.com/pkg/errors"
+	"github.com/sirupsen/logrus"
+)
+
+// VPC endpoints: https://docs.aws.amazon.com/sdk-for-go/api/service/ec2/#EC2.DescribeVpcEndpoints
+
+type VPCEndpoints struct{}
+
+func (VPCEndpoints) MarkAndSweep(opts Options, set *Set) error {
+	logger := logrus.WithField("options", opts)
+	if !opts.EnableVPCEndpointsClean {
+		logger.Info("Disable vpc endpoints clean")
+		return nil
+	}
+	svc := ec2.New(opts.Session, aws.NewConfig().WithRegion(opts.Region))
+
+	var vpcEndPointsToDelete []*vpcEndpoint
+	pageFunc := func(page *ec2.DescribeVpcEndpointsOutput, _ bool) bool {
+		for _, vpce := range page.VpcEndpoints {
+			v := &vpcEndpoint{
+				Account: opts.Account,
+				Region:  opts.Region,
+				ID:      *vpce.VpcEndpointId,
+			}
+			tags := fromEC2Tags(vpce.Tags)
+			if !set.Mark(opts, v, nil, tags) {
+				continue
+			}
+			logger.Warningf("%s: deleting %T: %s (%s)", v.ARN(), v, v.ID, tags[NameTagKey])
+			if opts.DryRun {
+				continue
+			}
+			vpcEndPointsToDelete = append(vpcEndPointsToDelete, v)
+		}
+		return true
+	}
+
+	if err := svc.DescribeVpcEndpointsPages(&ec2.DescribeVpcEndpointsInput{}, pageFunc); err != nil {
+		return err
+	}
+
+	for _, v := range vpcEndPointsToDelete {
+		if _, err := svc.DeleteVpcEndpoints(&ec2.DeleteVpcEndpointsInput{VpcEndpointIds: []*string{&v.ID}}); err != nil {
+			logger.Warningf("%s: delete failed: %v", v.ARN(), err)
+		}
+	}
+
+	return nil
+}
+
+func (VPCEndpoints) ListAll(opts Options) (*Set, error) {
+	set := NewSet(0)
+	if !opts.EnableVPCEndpointsClean {
+		return set, nil
+	}
+	svc := ec2.New(opts.Session, aws.NewConfig().WithRegion(opts.Region))
+	input := &ec2.DescribeVpcEndpointsInput{}
+	err := svc.DescribeVpcEndpointsPages(input, func(page *ec2.DescribeVpcEndpointsOutput, _ bool) bool {
+		now := time.Now()
+		for _, vpce := range page.VpcEndpoints {
+			arn := vpcEndpoint{
+				Account: opts.Account,
+				Region:  opts.Region,
+				ID:      *vpce.VpcEndpointId,
+			}.ARN()
+			set.firstSeen[arn] = now
+		}
+		return true
+	})
+
+	return set, errors.Wrapf(err, "couldn't describe vpc endpoints for %q in %q", opts.Account, opts.Region)
+}
+
+type vpcEndpoint struct {
+	Account string
+	Region  string
+	ID      string
+}
+
+func (vp vpcEndpoint) ARN() string {
+	return fmt.Sprintf("arn:aws:ec2:%s:%s:vpcendpoint/%s", vp.Region, vp.Account, vp.ID)
+}
+
+func (vp vpcEndpoint) ResourceKey() string {
+	return vp.ARN()
+}

--- a/cmd/aws-janitor-boskos/main.go
+++ b/cmd/aws-janitor-boskos/main.go
@@ -43,19 +43,20 @@ import (
 )
 
 var (
-	boskosURL              = flag.String("boskos-url", "http://boskos", "Boskos URL")
-	rTypes                 common.CommaSeparatedStrings
-	username               = flag.String("username", "", "Username used to access the Boskos server")
-	passwordFile           = flag.String("password-file", "", "The path to password file used to access the Boskos server")
-	region                 = flag.String("region", "", "The region to clean (otherwise defaults to all regions)")
-	sweepCount             = flag.Int("sweep-count", 5, "Number of times to sweep the resources")
-	sweepSleep             = flag.String("sweep-sleep", "30s", "The duration to pause between sweeps")
-	sweepSleepDuration     time.Duration
-	logLevel               = flag.String("log-level", "info", fmt.Sprintf("Log level is one of %v.", logrus.AllLevels))
-	dryRun                 = flag.Bool("dry-run", false, "If set, don't delete any resources, only log what would be done")
-	ttlTagKey              = flag.String("ttl-tag-key", "", "If set, allow resources to use a tag with this key to override TTL")
-	enableTargetGroupClean = flag.Bool("enable-target-group-clean", false, "If true, clean target groups.")
-	enableKeyPairsClean    = flag.Bool("enable-key-pairs-clean", false, "If true, clean key pairs.")
+	boskosURL               = flag.String("boskos-url", "http://boskos", "Boskos URL")
+	rTypes                  common.CommaSeparatedStrings
+	username                = flag.String("username", "", "Username used to access the Boskos server")
+	passwordFile            = flag.String("password-file", "", "The path to password file used to access the Boskos server")
+	region                  = flag.String("region", "", "The region to clean (otherwise defaults to all regions)")
+	sweepCount              = flag.Int("sweep-count", 5, "Number of times to sweep the resources")
+	sweepSleep              = flag.String("sweep-sleep", "30s", "The duration to pause between sweeps")
+	sweepSleepDuration      time.Duration
+	logLevel                = flag.String("log-level", "info", fmt.Sprintf("Log level is one of %v.", logrus.AllLevels))
+	dryRun                  = flag.Bool("dry-run", false, "If set, don't delete any resources, only log what would be done")
+	ttlTagKey               = flag.String("ttl-tag-key", "", "If set, allow resources to use a tag with this key to override TTL")
+	enableTargetGroupClean  = flag.Bool("enable-target-group-clean", false, "If true, clean target groups.")
+	enableKeyPairsClean     = flag.Bool("enable-key-pairs-clean", false, "If true, clean key pairs.")
+	enableVPCEndpointsClean = flag.Bool("enable-vpc-endpoints-clean", false, "If true, clean vpc endpoints.")
 
 	excludeTags common.CommaSeparatedStrings
 	includeTags common.CommaSeparatedStrings
@@ -182,14 +183,15 @@ func cleanResource(res *common.Resource) error {
 		return errors.Wrap(err, "Failed retrieving account")
 	}
 	opts := resources.Options{
-		Session:                s,
-		Account:                acct,
-		DryRun:                 *dryRun,
-		ExcludeTags:            excludeTM,
-		IncludeTags:            includeTM,
-		TTLTagKey:              *ttlTagKey,
-		EnableTargetGroupClean: *enableTargetGroupClean,
-		EnableKeyPairsClean:    *enableKeyPairsClean,
+		Session:                 s,
+		Account:                 acct,
+		DryRun:                  *dryRun,
+		ExcludeTags:             excludeTM,
+		IncludeTags:             includeTM,
+		TTLTagKey:               *ttlTagKey,
+		EnableTargetGroupClean:  *enableTargetGroupClean,
+		EnableKeyPairsClean:     *enableKeyPairsClean,
+		EnableVPCEndpointsClean: *enableVPCEndpointsClean,
 	}
 
 	logrus.WithField("name", res.Name).Info("beginning cleaning")

--- a/cmd/aws-janitor/main.go
+++ b/cmd/aws-janitor/main.go
@@ -40,16 +40,17 @@ import (
 )
 
 var (
-	maxTTL                 = flag.Duration("ttl", 24*time.Hour, "Maximum time before attempting to delete a resource. Set to 0s to nuke all non-default resources.")
-	region                 = flag.String("region", "", "The region to clean (otherwise defaults to all regions)")
-	path                   = flag.String("path", "", "S3 path for mark data (required when -all=false)")
-	cleanAll               = flag.Bool("all", false, "Clean all resources (ignores -path)")
-	logLevel               = flag.String("log-level", "info", fmt.Sprintf("Log level is one of %v.", logrus.AllLevels))
-	dryRun                 = flag.Bool("dry-run", false, "If set, don't delete any resources, only log what would be done")
-	ttlTagKey              = flag.String("ttl-tag-key", "", "If set, allow resources to use a tag with this key to override TTL")
-	pushGateway            = flag.String("push-gateway", "", "If specified, push prometheus metrics to this endpoint.")
-	enableTargetGroupClean = flag.Bool("enable-target-group-clean", false, "If true, clean target groups.")
-	enableKeyPairsClean    = flag.Bool("enable-key-pairs-clean", false, "If true, clean key pairs.")
+	maxTTL                  = flag.Duration("ttl", 24*time.Hour, "Maximum time before attempting to delete a resource. Set to 0s to nuke all non-default resources.")
+	region                  = flag.String("region", "", "The region to clean (otherwise defaults to all regions)")
+	path                    = flag.String("path", "", "S3 path for mark data (required when -all=false)")
+	cleanAll                = flag.Bool("all", false, "Clean all resources (ignores -path)")
+	logLevel                = flag.String("log-level", "info", fmt.Sprintf("Log level is one of %v.", logrus.AllLevels))
+	dryRun                  = flag.Bool("dry-run", false, "If set, don't delete any resources, only log what would be done")
+	ttlTagKey               = flag.String("ttl-tag-key", "", "If set, allow resources to use a tag with this key to override TTL")
+	pushGateway             = flag.String("push-gateway", "", "If specified, push prometheus metrics to this endpoint.")
+	enableTargetGroupClean  = flag.Bool("enable-target-group-clean", false, "If true, clean target groups.")
+	enableKeyPairsClean     = flag.Bool("enable-key-pairs-clean", false, "If true, clean key pairs.")
+	enableVPCEndpointsClean = flag.Bool("enable-vpc-endpoints-clean", false, "If true, clean vpc endpoints.")
 
 	excludeTags common.CommaSeparatedStrings
 	includeTags common.CommaSeparatedStrings
@@ -128,14 +129,15 @@ func main() {
 	}
 
 	opts := resources.Options{
-		Session:                sess,
-		Account:                acct,
-		DryRun:                 *dryRun,
-		ExcludeTags:            excludeTM,
-		IncludeTags:            includeTM,
-		TTLTagKey:              *ttlTagKey,
-		EnableTargetGroupClean: *enableTargetGroupClean,
-		EnableKeyPairsClean:    *enableKeyPairsClean,
+		Session:                 sess,
+		Account:                 acct,
+		DryRun:                  *dryRun,
+		ExcludeTags:             excludeTM,
+		IncludeTags:             includeTM,
+		TTLTagKey:               *ttlTagKey,
+		EnableTargetGroupClean:  *enableTargetGroupClean,
+		EnableKeyPairsClean:     *enableKeyPairsClean,
+		EnableVPCEndpointsClean: *enableVPCEndpointsClean,
 	}
 
 	if *cleanAll {

--- a/cmd/aws-resources-list/main.go
+++ b/cmd/aws-resources-list/main.go
@@ -28,15 +28,24 @@ import (
 )
 
 var (
-	region                 = flag.String("region", "", "Region to list (defaults to all)")
-	enableTargetGroupClean = flag.Bool("enable-target-group-clean", false, "If true, clean target groups.")
-	enableKeyPairsClean    = flag.Bool("enable-key-pairs-clean", false, "If true, clean key pairs.")
+	region                  = flag.String("region", "", "Region to list (defaults to all)")
+	enableTargetGroupClean  = flag.Bool("enable-target-group-clean", false, "If true, clean target groups.")
+	enableKeyPairsClean     = flag.Bool("enable-key-pairs-clean", false, "If true, clean key pairs.")
+	enableVPCEndpointsClean = flag.Bool("enable-vpc-endpoints-clean", false, "If true, clean vpc endpoints.")
 )
 
 func listResources(res resources.Type, sess *session.Session, acct string, regions []string) {
 	fmt.Printf("==%T==\n", res)
 	for _, region := range regions {
-		set, err := res.ListAll(resources.Options{Session: sess, Account: acct, Region: region, DryRun: true, EnableTargetGroupClean: *enableTargetGroupClean, EnableKeyPairsClean: *enableKeyPairsClean})
+		set, err := res.ListAll(resources.Options{
+			Session:                 sess,
+			Account:                 acct,
+			Region:                  region,
+			DryRun:                  true,
+			EnableTargetGroupClean:  *enableTargetGroupClean,
+			EnableKeyPairsClean:     *enableKeyPairsClean,
+			EnableVPCEndpointsClean: *enableVPCEndpointsClean,
+		})
 		if err != nil {
 			fmt.Fprintf(os.Stderr, "error listing %T: %v\n", res, err)
 			continue


### PR DESCRIPTION
For now, the vpc endpoints(https://docs.aws.amazon.com/sdk-for-go/api/service/ec2/#EC2.DescribeVpcEndpoints) are not GCed by the aws-janitor, this change intends to support that.

TESTED=I run make, make test and make verify locally, not error found.
Tried:
go run cmd/aws-janitor/main.go --dry-run=true --all=true
go run cmd/aws-janitor/main.go --dry-run=true --all=true --enable-vpc-endpoints-clean=true
locally
The log looks good to me