### PR TITLE
Skip management check for route35 zones and resources

### DIFF
--- a/aws-janitor/resources/list.go
+++ b/aws-janitor/resources/list.go
@@ -48,6 +48,9 @@ type Options struct {
 
 	// If true, clean VPC endpoints.
 	EnableVPCEndpointsClean bool
+
+	// If true, skip managed zone check and managed resource name check.
+	SkipRoute53ManagementCheck bool
 }
 
 type Type interface {

--- a/aws-janitor/resources/route53.go
+++ b/aws-janitor/resources/route53.go
@@ -85,7 +85,7 @@ func route53ResourceRecordSetsForZone(opts Options, logger logrus.FieldLogger, s
 
 	recordsPageFunc := func(records *route53.ListResourceRecordSetsOutput, _ bool) bool {
 		for _, rrs := range records.ResourceRecordSets {
-			if !resourceRecordSetIsManaged(rrs) {
+			if !opts.SkipRoute53ManagementCheck && !resourceRecordSetIsManaged(rrs) {
 				continue
 			}
 
@@ -119,7 +119,7 @@ func (rrs Route53ResourceRecordSets) MarkAndSweep(opts Options, set *Set) error 
 	pageFunc := func(zs *route53.ListHostedZonesOutput, _ bool) bool {
 		// Because route53 has such low rate limits, we collect the changes per-zone, to minimize API calls
 		for _, z := range zs.HostedZones {
-			if !zoneIsManaged(z) {
+			if !opts.SkipRoute53ManagementCheck && !zoneIsManaged(z) {
 				continue
 			}
 
@@ -193,7 +193,7 @@ func (Route53ResourceRecordSets) ListAll(opts Options) (*Set, error) {
 	err := svc.ListHostedZonesPages(&route53.ListHostedZonesInput{}, func(zones *route53.ListHostedZonesOutput, _ bool) bool {
 		for _, z := range zones.HostedZones {
 			zone := z
-			if !zoneIsManaged(zone) {
+			if !opts.SkipRoute53ManagementCheck && !zoneIsManaged(zone) {
 				continue
 			}
 			// ListHostedZones returns "/hostedzone/ABCDEF12345678" but other Route53 endpoints expect "ABCDEF12345678"

--- a/cmd/aws-janitor-boskos/main.go
+++ b/cmd/aws-janitor-boskos/main.go
@@ -43,20 +43,21 @@ import (
 )
 
 var (
-	boskosURL               = flag.String("boskos-url", "http://boskos", "Boskos URL")
-	rTypes                  common.CommaSeparatedStrings
-	username                = flag.String("username", "", "Username used to access the Boskos server")
-	passwordFile            = flag.String("password-file", "", "The path to password file used to access the Boskos server")
-	region                  = flag.String("region", "", "The region to clean (otherwise defaults to all regions)")
-	sweepCount              = flag.Int("sweep-count", 5, "Number of times to sweep the resources")
-	sweepSleep              = flag.String("sweep-sleep", "30s", "The duration to pause between sweeps")
-	sweepSleepDuration      time.Duration
-	logLevel                = flag.String("log-level", "info", fmt.Sprintf("Log level is one of %v.", logrus.AllLevels))
-	dryRun                  = flag.Bool("dry-run", false, "If set, don't delete any resources, only log what would be done")
-	ttlTagKey               = flag.String("ttl-tag-key", "", "If set, allow resources to use a tag with this key to override TTL")
-	enableTargetGroupClean  = flag.Bool("enable-target-group-clean", false, "If true, clean target groups.")
-	enableKeyPairsClean     = flag.Bool("enable-key-pairs-clean", false, "If true, clean key pairs.")
-	enableVPCEndpointsClean = flag.Bool("enable-vpc-endpoints-clean", false, "If true, clean vpc endpoints.")
+	boskosURL                  = flag.String("boskos-url", "http://boskos", "Boskos URL")
+	rTypes                     common.CommaSeparatedStrings
+	username                   = flag.String("username", "", "Username used to access the Boskos server")
+	passwordFile               = flag.String("password-file", "", "The path to password file used to access the Boskos server")
+	region                     = flag.String("region", "", "The region to clean (otherwise defaults to all regions)")
+	sweepCount                 = flag.Int("sweep-count", 5, "Number of times to sweep the resources")
+	sweepSleep                 = flag.String("sweep-sleep", "30s", "The duration to pause between sweeps")
+	sweepSleepDuration         time.Duration
+	logLevel                   = flag.String("log-level", "info", fmt.Sprintf("Log level is one of %v.", logrus.AllLevels))
+	dryRun                     = flag.Bool("dry-run", false, "If set, don't delete any resources, only log what would be done")
+	ttlTagKey                  = flag.String("ttl-tag-key", "", "If set, allow resources to use a tag with this key to override TTL")
+	enableTargetGroupClean     = flag.Bool("enable-target-group-clean", false, "If true, clean target groups.")
+	enableKeyPairsClean        = flag.Bool("enable-key-pairs-clean", false, "If true, clean key pairs.")
+	enableVPCEndpointsClean    = flag.Bool("enable-vpc-endpoints-clean", false, "If true, clean vpc endpoints.")
+	skipRoute53ManagementCheck = flag.Bool("skip-route53-management-check", false, "If true, skip managed zone check and managed resource name check.")
 
 	excludeTags common.CommaSeparatedStrings
 	includeTags common.CommaSeparatedStrings
@@ -183,15 +184,16 @@ func cleanResource(res *common.Resource) error {
 		return errors.Wrap(err, "Failed retrieving account")
 	}
 	opts := resources.Options{
-		Session:                 s,
-		Account:                 acct,
-		DryRun:                  *dryRun,
-		ExcludeTags:             excludeTM,
-		IncludeTags:             includeTM,
-		TTLTagKey:               *ttlTagKey,
-		EnableTargetGroupClean:  *enableTargetGroupClean,
-		EnableKeyPairsClean:     *enableKeyPairsClean,
-		EnableVPCEndpointsClean: *enableVPCEndpointsClean,
+		Session:                    s,
+		Account:                    acct,
+		DryRun:                     *dryRun,
+		ExcludeTags:                excludeTM,
+		IncludeTags:                includeTM,
+		TTLTagKey:                  *ttlTagKey,
+		EnableTargetGroupClean:     *enableTargetGroupClean,
+		EnableKeyPairsClean:        *enableKeyPairsClean,
+		EnableVPCEndpointsClean:    *enableVPCEndpointsClean,
+		SkipRoute53ManagementCheck: *skipRoute53ManagementCheck,
 	}
 
 	logrus.WithField("name", res.Name).Info("beginning cleaning")

--- a/cmd/aws-janitor/main.go
+++ b/cmd/aws-janitor/main.go
@@ -40,17 +40,18 @@ import (
 )
 
 var (
-	maxTTL                  = flag.Duration("ttl", 24*time.Hour, "Maximum time before attempting to delete a resource. Set to 0s to nuke all non-default resources.")
-	region                  = flag.String("region", "", "The region to clean (otherwise defaults to all regions)")
-	path                    = flag.String("path", "", "S3 path for mark data (required when -all=false)")
-	cleanAll                = flag.Bool("all", false, "Clean all resources (ignores -path)")
-	logLevel                = flag.String("log-level", "info", fmt.Sprintf("Log level is one of %v.", logrus.AllLevels))
-	dryRun                  = flag.Bool("dry-run", false, "If set, don't delete any resources, only log what would be done")
-	ttlTagKey               = flag.String("ttl-tag-key", "", "If set, allow resources to use a tag with this key to override TTL")
-	pushGateway             = flag.String("push-gateway", "", "If specified, push prometheus metrics to this endpoint.")
-	enableTargetGroupClean  = flag.Bool("enable-target-group-clean", false, "If true, clean target groups.")
-	enableKeyPairsClean     = flag.Bool("enable-key-pairs-clean", false, "If true, clean key pairs.")
-	enableVPCEndpointsClean = flag.Bool("enable-vpc-endpoints-clean", false, "If true, clean vpc endpoints.")
+	maxTTL                     = flag.Duration("ttl", 24*time.Hour, "Maximum time before attempting to delete a resource. Set to 0s to nuke all non-default resources.")
+	region                     = flag.String("region", "", "The region to clean (otherwise defaults to all regions)")
+	path                       = flag.String("path", "", "S3 path for mark data (required when -all=false)")
+	cleanAll                   = flag.Bool("all", false, "Clean all resources (ignores -path)")
+	logLevel                   = flag.String("log-level", "info", fmt.Sprintf("Log level is one of %v.", logrus.AllLevels))
+	dryRun                     = flag.Bool("dry-run", false, "If set, don't delete any resources, only log what would be done")
+	ttlTagKey                  = flag.String("ttl-tag-key", "", "If set, allow resources to use a tag with this key to override TTL")
+	pushGateway                = flag.String("push-gateway", "", "If specified, push prometheus metrics to this endpoint.")
+	enableTargetGroupClean     = flag.Bool("enable-target-group-clean", false, "If true, clean target groups.")
+	enableKeyPairsClean        = flag.Bool("enable-key-pairs-clean", false, "If true, clean key pairs.")
+	enableVPCEndpointsClean    = flag.Bool("enable-vpc-endpoints-clean", false, "If true, clean vpc endpoints.")
+	skipRoute53ManagementCheck = flag.Bool("skip-route53-management-check", false, "If true, skip managed zone check and managed resource name check.")
 
 	excludeTags common.CommaSeparatedStrings
 	includeTags common.CommaSeparatedStrings
@@ -129,15 +130,16 @@ func main() {
 	}
 
 	opts := resources.Options{
-		Session:                 sess,
-		Account:                 acct,
-		DryRun:                  *dryRun,
-		ExcludeTags:             excludeTM,
-		IncludeTags:             includeTM,
-		TTLTagKey:               *ttlTagKey,
-		EnableTargetGroupClean:  *enableTargetGroupClean,
-		EnableKeyPairsClean:     *enableKeyPairsClean,
-		EnableVPCEndpointsClean: *enableVPCEndpointsClean,
+		Session:                    sess,
+		Account:                    acct,
+		DryRun:                     *dryRun,
+		ExcludeTags:                excludeTM,
+		IncludeTags:                includeTM,
+		TTLTagKey:                  *ttlTagKey,
+		EnableTargetGroupClean:     *enableTargetGroupClean,
+		EnableKeyPairsClean:        *enableKeyPairsClean,
+		EnableVPCEndpointsClean:    *enableVPCEndpointsClean,
+		SkipRoute53ManagementCheck: *skipRoute53ManagementCheck,
 	}
 
 	if *cleanAll {

--- a/cmd/aws-resources-list/main.go
+++ b/cmd/aws-resources-list/main.go
@@ -28,23 +28,25 @@ import (
 )
 
 var (
-	region                  = flag.String("region", "", "Region to list (defaults to all)")
-	enableTargetGroupClean  = flag.Bool("enable-target-group-clean", false, "If true, clean target groups.")
-	enableKeyPairsClean     = flag.Bool("enable-key-pairs-clean", false, "If true, clean key pairs.")
-	enableVPCEndpointsClean = flag.Bool("enable-vpc-endpoints-clean", false, "If true, clean vpc endpoints.")
+	region                     = flag.String("region", "", "Region to list (defaults to all)")
+	enableTargetGroupClean     = flag.Bool("enable-target-group-clean", false, "If true, clean target groups.")
+	enableKeyPairsClean        = flag.Bool("enable-key-pairs-clean", false, "If true, clean key pairs.")
+	enableVPCEndpointsClean    = flag.Bool("enable-vpc-endpoints-clean", false, "If true, clean vpc endpoints.")
+	skipRoute53ManagementCheck = flag.Bool("skip-route53-management-check", false, "If true, skip managed zone check and managed resource name check.")
 )
 
 func listResources(res resources.Type, sess *session.Session, acct string, regions []string) {
 	fmt.Printf("==%T==\n", res)
 	for _, region := range regions {
 		set, err := res.ListAll(resources.Options{
-			Session:                 sess,
-			Account:                 acct,
-			Region:                  region,
-			DryRun:                  true,
-			EnableTargetGroupClean:  *enableTargetGroupClean,
-			EnableKeyPairsClean:     *enableKeyPairsClean,
-			EnableVPCEndpointsClean: *enableVPCEndpointsClean,
+			Session:                    sess,
+			Account:                    acct,
+			Region:                     region,
+			DryRun:                     true,
+			EnableTargetGroupClean:     *enableTargetGroupClean,
+			EnableKeyPairsClean:        *enableKeyPairsClean,
+			EnableVPCEndpointsClean:    *enableVPCEndpointsClean,
+			SkipRoute53ManagementCheck: *skipRoute53ManagementCheck,
 		})
 		if err != nil {
 			fmt.Fprintf(os.Stderr, "error listing %T: %v\n", res, err)


### PR DESCRIPTION
Add a flag to skip management check for route32 zones and resources
tried
go run cmd/aws-janitor/main.go --dry-run=true --all=true --skip-route53-management-check=true
locally
The log looks good to me