### PR TITLE
Fix a bug for aws iam roles clean up

### DIFF
--- a/aws-janitor/resources/iam_roles.go
+++ b/aws-janitor/resources/iam_roles.go
@@ -203,7 +203,6 @@ func (r iamRole) delete(svc *iam.IAM, logger logrus.FieldLogger) error {
 		if _, err := svc.DetachRolePolicy(detachRolePolicyReq); err != nil {
 			return errors.Wrapf(err, "error detaching IAM role policy %q %q", roleName, attachedRolePolicyArn)
 		}
-
 	}
 
 	logger.Debugf("Deleting IAM role %q", roleName)

--- a/aws-janitor/resources/list.go
+++ b/aws-janitor/resources/list.go
@@ -80,6 +80,7 @@ var RegionalTypeList = []Type{
 	LaunchConfigurations{},
 	LaunchTemplates{},
 	Instances{},
+	VPCEndpoints{},
 	// Addresses
 	NetworkInterfaces{},
 	Subnets{},
@@ -90,7 +91,6 @@ var RegionalTypeList = []Type{
 	RouteTables{},
 	NATGateway{},
 	VPCs{},
-	VPCEndpoints{},
 	DHCPOptions{},
 	Snapshots{},
 	Volumes{},


### PR DESCRIPTION
Many iam roles fail to be deleted due to attached policies they have. Before deleting iam roles, we should also detach those role policies.