### PR TITLE
Skip some resource record set types when deleting resource records

### DIFF
--- a/aws-janitor/resources/list.go
+++ b/aws-janitor/resources/list.go
@@ -57,6 +57,9 @@ type Options struct {
 
 	// If true, clean S3 Buckets.
 	EnableS3BucketsClean bool
+
+	// Resource record set types that shoud not be deleted.
+	SkipResourceRecordSetTypes map[string]bool
 }
 
 type Type interface {


### PR DESCRIPTION
Currently, we have error log:
unable to delete DNS records: InvalidChangeBatch: [A HostedZone must contain at least one NS record for the zone itself., A HostedZone must contain exactly one SOA record.]

Which means that the type "NS" and "SOA" should not be deleted.