### PR TITLE
Delete IAM policies when detaching them from IAM roles

### DIFF
--- a/aws-janitor/resources/list.go
+++ b/aws-janitor/resources/list.go
@@ -60,6 +60,9 @@ type Options struct {
 
 	// Resource record set types that shoud not be deleted.
 	SkipResourceRecordSetTypes map[string]bool
+
+	// If true, delete detached IAM policies when deleting IAM roles.
+	DeleteDetachedPolicy bool
 }
 
 type Type interface {

--- a/cmd/aws-janitor-boskos/main.go
+++ b/cmd/aws-janitor-boskos/main.go
@@ -60,6 +60,7 @@ var (
 	skipRoute53ManagementCheck = flag.Bool("skip-route53-management-check", false, "If true, skip managed zone check and managed resource name check.")
 	enableDNSZoneClean         = flag.Bool("enable-dns-zone-clean", false, "If true, clean DNS zones.")
 	enableS3BucketsClean       = flag.Bool("enable-s3-buckets-clean", false, "If true, clean S3 buckets.")
+	deleteDetachedPolicy       = flag.Bool("delete-detached-policy", false, "If true, delete detached IAM policies when deleting IAM roles.")
 
 	excludeTags                common.CommaSeparatedStrings
 	includeTags                common.CommaSeparatedStrings
@@ -215,6 +216,7 @@ func cleanResource(res *common.Resource) error {
 		EnableDNSZoneClean:         *enableDNSZoneClean,
 		EnableS3BucketsClean:       *enableS3BucketsClean,
 		SkipResourceRecordSetTypes: skipResourceRecordSetTypesSet,
+		DeleteDetachedPolicy:       *deleteDetachedPolicy,
 	}
 
 	logrus.WithField("name", res.Name).Info("beginning cleaning")

--- a/cmd/aws-janitor/main.go
+++ b/cmd/aws-janitor/main.go
@@ -54,6 +54,7 @@ var (
 	skipRoute53ManagementCheck = flag.Bool("skip-route53-management-check", false, "If true, skip managed zone check and managed resource name check.")
 	enableDNSZoneClean         = flag.Bool("enable-dns-zone-clean", false, "If true, clean DNS zones.")
 	enableS3BucketsClean       = flag.Bool("enable-s3-buckets-clean", false, "If true, clean S3 buckets.")
+	deleteDetachedPolicy       = flag.Bool("delete-detached-policy", false, "If true, delete detached IAM policies when deleting IAM roles.")
 
 	excludeTags                common.CommaSeparatedStrings
 	includeTags                common.CommaSeparatedStrings
@@ -160,6 +161,7 @@ func main() {
 		EnableDNSZoneClean:         *enableDNSZoneClean,
 		EnableS3BucketsClean:       *enableS3BucketsClean,
 		SkipResourceRecordSetTypes: skipResourceRecordSetTypesSet,
+		DeleteDetachedPolicy:       *deleteDetachedPolicy,
 	}
 
 	if *cleanAll {


### PR DESCRIPTION
Currently, when detaching IAM policies from IAM roles, we don't delete them and leave them orphaned.
In this change, when detaching IAM policies from IAM roles, we also check the AttachmentCount of those policies. If they no longer have any roles attached to, we delete them.