### PR TITLE
`boskos`: move names over different types

### DIFF
--- a/ranch/ranch_test.go
+++ b/ranch/ranch_test.go
@@ -1473,6 +1473,36 @@ func TestSyncResources(t *testing.T) {
 				},
 			}}},
 		},
+		{
+			name: "move names over types",
+			config: &common.BoskosConfig{Resources: []common.ResourceEntry{
+				{
+					Type:  "type-0",
+					State: common.Free,
+					Names: []string{
+						"res-0-type-0",
+					},
+				},
+				{
+					Type:  "type-1",
+					State: common.Free,
+					Names: []string{
+						"res-1-type-0",
+						"res-0-type-1",
+					},
+				},
+			}},
+			currentRes: []runtime.Object{
+				newResource("res-0-type-0", "type-0", common.Free, "", startTime),
+				newResource("res-1-type-0", "type-0", common.Free, "", startTime),
+				newResource("res-0-type-1", "type-1", common.Free, "", startTime),
+			},
+			expectedRes: &crds.ResourceObjectList{Items: []crds.ResourceObject{
+				*newResource("res-0-type-0", "type-0", common.Free, "", startTime),
+				*newResource("res-1-type-0", "type-1", common.Free, "", fakeNow),
+				*newResource("res-0-type-1", "type-1", common.Free, "", startTime),
+			}},
+		},
 	}
 
 	for _, tc := range testcases {

--- a/ranch/storage.go
+++ b/ranch/storage.go
@@ -557,16 +557,16 @@ func (s *Storage) syncStaticResources(newResourcesByName, existingResourcesByNam
 
 	// Delete resources
 	for _, res := range existingResourcesByName {
-		_, exists := newResourcesByName[res.Name]
-		if !exists {
+		r, exists := newResourcesByName[res.Name]
+		if !exists || r.Spec.Type != res.Spec.Type {
 			resToDelete = append(resToDelete, res)
 		}
 	}
 
 	// Add new resources
 	for _, res := range newResourcesByName {
-		_, exists := existingResourcesByName[res.Name]
-		if !exists {
+		r, exists := existingResourcesByName[res.Name]
+		if !exists || r.Spec.Type != res.Spec.Type {
 			resToAdd = append(resToAdd, res)
 		}
 	}


### PR DESCRIPTION
`boskos` doesn't currently support moving a static resource name from one type to another; this PR tries fill the gap and overcome this limitation.

Example (as-is):

The following configuration:
```yaml
resources:
- type: type-0
  names:
  - type-0-name-0
  - type-0-name-1
  state: free
- type: type-1
  names:
  - type-1-name-0
  state: free
```
produces these resources:
```sh
$ oc get resources
NAME            TYPE     STATE   OWNER   LAST-UPDATED
type-0-name-0   type-0   free            60m
type-0-name-1   type-0   free            60m
type-1-name-0   type-1   free            60m
```

but when it changes to:
```yaml
resources:
- type: type-0
  names:
  - type-0-name-0
  state: free
- type: type-1
  names:
  - type-1-name-0
  - type-0-name-1
  state: free
```

the resources aren't updated accordingly:
```sh
$ oc get resources
NAME            TYPE     STATE   OWNER   LAST-UPDATED
type-0-name-0   type-0   free            62m
type-0-name-1   type-0   free            62m
type-1-name-0   type-1   free            62m
```
but it should have been:
```diff
$ oc get resources
NAME            TYPE     STATE   OWNER   LAST-UPDATED
type-0-name-0   type-0   free            62m
- type-0-name-1   type-0   free            62m
+ type-0-name-1   type-1   free            62m
type-1-name-0   type-1   free            62m
```