### PR TITLE
Update gcloud version to the latest for the janitor image

### DIFF
--- a/images/janitor/Dockerfile
+++ b/images/janitor/Dockerfile
@@ -35,7 +35,7 @@ RUN make build
 ARG cmd
 RUN make "${cmd}"
 
-FROM gcr.io/google.com/cloudsdktool/cloud-sdk:375.0.0-slim
+FROM gcr.io/google.com/cloudsdktool/cloud-sdk:431.0.0-slim
 COPY ./cmd/janitor/gcp_janitor.py /bin
 
 ARG cmd


### PR DESCRIPTION
gcloud behaviour has been changed recently for registering a cluster in a fleet. Now default behaviour is to register in cluster's region and not global. Previous gcloud versions still try to un-register from global location only and are not forward compatible.