### PR TITLE
Adds extra step to delete secondary ip ranges before cluster deletion

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -93,7 +93,7 @@ verify-boilerplate:
 .PHONY: verify-lint
 # TODO(ixdy): fix legacy errors and remove --new-from-rev
 verify-lint: $(GOLANGCI_LINT)
-	./hack/tools/bin/golangci-lint run --max-issues-per-linter 0 --max-same-issues 0 -v --new-from-rev HEAD~
+	./hack/tools/bin/golangci-lint run --timeout='2m0s' --max-issues-per-linter 0 --max-same-issues 0 -v --new-from-rev HEAD~
 
 .PHONY: verify-codegen
 verify-codegen: $(CONTROLLER_GEN)


### PR DESCRIPTION
Janitor is failing to delete networks because they have ip ranges left over from tests. Adding a way to figure the secondary ip ranges and delete them before starting cluster deletion.