### PR TITLE
gcp_janitor.py: cleanup security-policies

### DIFF
--- a/cmd/janitor/gcp_janitor.py
+++ b/cmd/janitor/gcp_janitor.py
@@ -62,6 +62,8 @@ RESOURCES_BY_API = {
         Resource('', 'compute', 'backend-services', None, 'global', None, False, True, None),
         Resource('', 'compute', 'backend-services', None, 'region', None, False, True, None),
         Resource('', 'compute', 'target-pools', None, 'region', None, False, True, None),
+        Resource('', 'compute', 'security-policies', None, 'global', None, False, True, None),
+        Resource('', 'compute', 'security-policies', None, 'region', None, False, True, None),
         Resource('', 'compute', 'health-checks', None, 'global', None, False, True, None),
         Resource('', 'compute', 'health-checks', None, 'region', None, False, True, None),
         Resource('', 'compute', 'http-health-checks', None, None, None, False, True, None),


### PR DESCRIPTION
* Add security-policies to the list of resources for cleanup.
* Cleanup should be done for both regional and glocal policies.
* Security policies have dependencies on backend services, target pools, target instances, and instances. Thus, its cleanup should be after the cleanups of these resources.