### PR TITLE
Cleanup OIDC providers created by eksctl for `ci-shared-aws`

### DIFF
--- a/aws-janitor/resources/iam_oidc_providers.go
+++ b/aws-janitor/resources/iam_oidc_providers.go
@@ -61,10 +61,9 @@ func fetchOIDCProviderAndTags(ctx context.Context, svc *iam.IAM, arn string) (*i
 func oidcProviderIsManaged(_oidcProvider *iam.GetOpenIDConnectProviderOutput, tags Tags) bool {
 	// Look for one of the kubernetes cluster ownership tags
 	for k := range tags {
-		if strings.HasPrefix(k, "kubernetes.io/cluster/") {
-			return true
-		}
-		if k == "KubernetesCluster" {
+		if strings.HasPrefix(k, "kubernetes.io/cluster/") ||
+			strings.HasPrefix(k, "alpha.eksctl.io/cluster-name") ||
+			k == "KubernetesCluster" {
 			return true
 		}
 	}


### PR DESCRIPTION
### What is this PR about?

aws-janitor is not cleaning up OIDC providers created by `eksctl` during EKS cluster creation process in the community account. This PR resolves https://github.com/kubernetes/k8s.io/issues/6300

cc: @dims 