### PR TITLE
ssl-policies should be cleaned up after target-https-proxies.

### DIFF
--- a/cmd/janitor/gcp_janitor.py
+++ b/cmd/janitor/gcp_janitor.py
@@ -40,8 +40,6 @@ RESOURCES_BY_API = {
 
     # compute resources
     'compute.googleapis.com': [
-        Resource('', 'compute', 'ssl-policies', None, 'global', None, False, True, None),
-        Resource('', 'compute', 'ssl-policies', None, 'region', None, False, True, None),
         Resource('', 'compute', 'instances', None, 'zone', None, False, True, None),
         Resource('', 'compute', 'addresses', None, 'global', None, False, True, None),
         Resource('', 'compute', 'addresses', None, 'region', None, False, True, None),
@@ -55,6 +53,8 @@ RESOURCES_BY_API = {
         Resource('', 'compute', 'target-https-proxies', None, 'global', None, False, True, None),
         Resource('', 'compute', 'target-https-proxies', None, 'region', None, False, True, None),
         Resource('', 'compute', 'target-tcp-proxies', None, None, None, False, True, None),
+        Resource('', 'compute', 'ssl-policies', None, 'global', None, False, True, None),
+        Resource('', 'compute', 'ssl-policies', None, 'region', None, False, True, None),
         Resource('', 'compute', 'ssl-certificates', None, 'global', None, False, True, None),
         Resource('', 'compute', 'ssl-certificates', None, 'region', None, False, True, None),
         Resource('', 'compute', 'url-maps', None, 'global', None, False, True, None),


### PR DESCRIPTION
Based on https://cloud.google.com/load-balancing/docs/use-ssl-policies#delete-policy, ssl-policies should be cleaned up after target-https-proxies.

/assign @krzyzacy 