### PR TITLE
Bump alpine_version in boskosctl image to 3.17.

### DIFF
--- a/images/boskosctl/Dockerfile
+++ b/images/boskosctl/Dockerfile
@@ -15,7 +15,7 @@
 # Installs a few extra tools folks might want to use when running boskosctl.
 
 ARG go_version
-ARG alpine_version=3.16
+ARG alpine_version=3.17
 
 FROM golang:${go_version}-alpine${alpine_version} as build
 WORKDIR /go/src/app


### PR DESCRIPTION
golang:1.19.12-alpine3.16 doesn't actually exist and is causing the image postsubmit to fail:

https://prow.k8s.io/view/gs/kubernetes-jenkins/logs/post-boskos-push-images/1755036868031811584