### PR TITLE
Allow janitor to reload resource types from a config file

### DIFF
--- a/cmd/janitor/janitor.go
+++ b/cmd/janitor/janitor.go
@@ -45,7 +45,8 @@ var (
 
 func init() {
 	flag.Var(&rTypes, "resource-type", "comma-separated list of resources need to be cleaned up")
-	flag.StringVar(&rTypesConfig, "resource-type-from-config", "", "extract a list of resources need to be cleaned up from boskos' config file")
+	flag.StringVar(&rTypesConfig, "resource-type-from-config", "", "extract a list of resources need to be cleaned up from boskos' config file; "+
+		"if both resource-type and resource-type-from-config are specified, resource-type will take priority")
 	flag.IntVar(&poolSize, "pool-size", 20, "number of concurrent janitor goroutine")
 	flag.DurationVar(&updateFrequency, "update-frequency", 5*time.Minute, "How often to heartbeat owning resources.")
 }

--- a/cmd/janitor/janitor.go
+++ b/cmd/janitor/janitor.go
@@ -33,6 +33,7 @@ import (
 var (
 	bufferSize      = 1 // Maximum holding resources
 	rTypes          common.CommaSeparatedStrings
+	rTypesConfig    string
 	poolSize        int
 	updateFrequency time.Duration
 	janitorPath     = flag.String("janitor-path", "/bin/gcp_janitor.py", "Path to janitor binary path")
@@ -44,6 +45,7 @@ var (
 
 func init() {
 	flag.Var(&rTypes, "resource-type", "comma-separated list of resources need to be cleaned up")
+	flag.StringVar(&rTypesConfig, "resource-type-from-config", "", "extract a list of resources need to be cleaned up from boskos' config file")
 	flag.IntVar(&poolSize, "pool-size", 20, "number of concurrent janitor goroutine")
 	flag.DurationVar(&updateFrequency, "update-frequency", 5*time.Minute, "How often to heartbeat owning resources.")
 }
@@ -66,9 +68,15 @@ func main() {
 	}
 	logrus.Info("Initialized boskos client!")
 
-	if len(rTypes) == 0 {
-		logrus.Fatal("--resource-type must not be empty!")
+	if len(rTypes) == 0 && rTypesConfig == "" {
+		logrus.Fatal("--resource-type or --resource-type-from-config must be set")
 	}
+
+	var rt common.ResourceTypes
+	if rt, err = common.NewResourceTypes(rTypes, rTypesConfig); err != nil {
+		logrus.WithError(err).Fatal("new resource types")
+	}
+	logrus.Infof("initialized resource types: %+v", rt.Types())
 
 	go func(boskos boskosClient) {
 		for range time.Tick(updateFrequency) {
@@ -81,7 +89,7 @@ func main() {
 	buffer := setup(boskos, poolSize, bufferSize, janitorClean, extraJanitorFlags)
 
 	for {
-		run(boskos, buffer, rTypes)
+		run(boskos, buffer, rt.Types())
 		time.Sleep(time.Minute)
 	}
 }

--- a/cmd/reaper/reaper.go
+++ b/cmd/reaper/reaper.go
@@ -66,8 +66,8 @@ func main() {
 		logrus.Fatal("--target-state must not be empty!")
 	}
 
-	var rt ResourceTypes
-	if rt, err = NewResourceTypes(rTypes, rTypesConfig); err != nil {
+	var rt common.ResourceTypes
+	if rt, err = common.NewResourceTypes(rTypes, rTypesConfig); err != nil {
 		logrus.WithError(err).Fatal("new resource types")
 	}
 	logrus.Info("initialized resource types")

--- a/common/resource_types.go
+++ b/common/resource_types.go
@@ -14,7 +14,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-package main
+package common
 
 import (
 	"fmt"
@@ -24,7 +24,6 @@ import (
 	"github.com/sirupsen/logrus"
 	"github.com/spf13/viper"
 	"k8s.io/apimachinery/pkg/util/sets"
-	"sigs.k8s.io/boskos/common"
 )
 
 type ResourceTypes interface {
@@ -105,11 +104,11 @@ func (rtw *resourceTypesWatcher) Types() []string {
 
 func parseResourceTypesFromConfig(config string) ([]string, error) {
 	types := make([]string, 0)
-	cfg, err := common.ParseConfig(config)
+	cfg, err := ParseConfig(config)
 	if err != nil {
 		return types, fmt.Errorf("parse config %q: %w", config, err)
 	}
-	if err := common.ValidateConfig(cfg); err != nil {
+	if err := ValidateConfig(cfg); err != nil {
 		return types, fmt.Errorf("validate config %q: %w", config, err)
 	}
 	for _, r := range cfg.Resources {

--- a/common/resource_types_test.go
+++ b/common/resource_types_test.go
@@ -14,7 +14,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-package main
+package common
 
 import (
 	"io/ioutil"


### PR DESCRIPTION
Building on top of https://github.com/kubernetes-sigs/boskos/pull/157

This PR allows the janitor to read the resource types from the given config file instead of reading directly from the arguments. Upon updates to the resource types, the janitor can reload the types on the file so no need to restart the deployment.