### PR TITLE
Bump Go and Alpine versions

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -40,7 +40,7 @@ CONTROLLER_GEN := $(TOOLS_BIN_DIR)/$(CONTROLLER_GEN_BIN)-$(CONTROLLER_GEN_VER)
 
 CMDS = $(notdir $(shell find ./cmd/ -maxdepth 1 -type d | sort))
 
-export GO_VERSION=1.22.3
+export GO_VERSION=1.22.5
 export GO111MODULE=on
 export DOCKER_REPO
 export DOCKER_TAG

--- a/images/boskosctl/Dockerfile
+++ b/images/boskosctl/Dockerfile
@@ -15,7 +15,7 @@
 # Installs a few extra tools folks might want to use when running boskosctl.
 
 ARG go_version
-ARG alpine_version=3.17
+ARG alpine_version=3.20
 
 FROM golang:${go_version}-alpine${alpine_version} as build
 WORKDIR /go/src/app


### PR DESCRIPTION
Docker image fails to build, logs are [here](https://storage.googleapis.com/kubernetes-jenkins/logs/post-boskos-push-images/1818709268862341120/build-log.txt).
```
Step 1/18 : ARG go_version
Step 2/18 : ARG alpine_version=3.17
Step 3/18 : FROM golang:${go_version}-alpine${alpine_version} as build
manifest for golang:1.22.3-alpine3.17 not found: manifest unknown: manifest unknown
make: *** [Makefile:78: boskosctl-image] Error 1
ERROR
ERROR: build step 0 "gcr.io/k8s-staging-test-infra/gcb-docker-gcloud:v20210917-12df099d55" failed: step exited with non-zero status: 2
```

Pick a newer image [docker.io/library/golang](https://explore.ggcr.dev/?repo=docker.io/library/golang):[1.22.5-alpine3.20](https://explore.ggcr.dev/?image=docker.io/library/golang:1.22.5-alpine3.20&mt=application%2Fvnd.oci.image.index.v1%2Bjson) instead of the missing one!