### PR TITLE
Update to debian12 to get latest glibc

### DIFF
--- a/images/default/Dockerfile
+++ b/images/default/Dockerfile
@@ -35,7 +35,7 @@ RUN make build
 ARG cmd
 RUN make "${cmd}"
 
-FROM gcr.io/distroless/base-debian10
+FROM gcr.io/distroless/base-debian12
 
 ARG cmd
 COPY --from=build "/go/src/app/_output/bin/${cmd}" /app


### PR DESCRIPTION
We reverted the previous image because of GLIBC issue https://github.com/kubernetes/test-infra/pull/33184

let's switch to newer debian which is used in k/release and elsewhere:
https://cs.k8s.io/?q=gcr.io%2Fdistroless%2Fbase-debian1&i=nope&files=&excludeFiles=&repos=