### PR TITLE
Use default region if LocationConstraint not found from s3 bucket

### DIFF
--- a/aws-janitor/s3/s3.go
+++ b/aws-janitor/s3/s3.go
@@ -51,7 +51,10 @@ func GetPath(cfg *aws2.Config, s string) (*Path, error) {
 		return nil, err
 	}
 
-	region := resp.LocationConstraint
+	region := regions.Default
+	if resp.LocationConstraint != "" {
+		region = string(resp.LocationConstraint)
+	}
 
 	return &Path{Region: string(region), Bucket: url.Host, Key: url.Path}, nil
 }


### PR DESCRIPTION
Failure in:
- https://storage.googleapis.com/kubernetes-jenkins/logs/maintenance-ci-shared-aws-janitor/1818809423779336192/build-log.txt
- https://storage.googleapis.com/kubernetes-jenkins/logs/ci-aws-ec2-janitor/1818809392036843520/build-log.txt

Because i missed some logic when converting from v1 to v2, specifically:
https://github.com/kubernetes-sigs/boskos/blame/210745d604c7bcd375251640e39b076a3467cb43/aws-janitor/s3/s3.go#L53-L56