### PR TITLE
Use standard boskos released projects state = dirty in boskosctl example

### DIFF
--- a/cmd/boskosctl/README.md
+++ b/cmd/boskosctl/README.md
@@ -28,7 +28,7 @@ resource="$( boskosctlwrapper acquire --type things --state new --target-state o
 # release the resource when the script exits
 function release() {
     local resource_name; resource_name="$( jq .name <<<"${resource}" )"
-    boskosctlwrapper release --name "${resource_name}" --target-state used
+    boskosctlwrapper release --name "${resource_name}" --target-state dirty
 }
 trap release EXIT
 


### PR DESCRIPTION
Use standard boskos released projects state = dirty in boskosctl example


The standard expected states are here:
https://github.com/kubernetes-sigs/boskos/blob/1221bfe2f633fe5eea83125d32b782c07204c2e9/common/common.go#L30-L46

I think this explains why we have some projects stuck in state "other", it got copy-pasted to image-builder here: https://github.com/kubernetes-sigs/image-builder/blob/f09c4f6be1aa2916ff27d23b459e8fb536a058ca/images/capi/scripts/ci-gce.sh#L53

We should use "dirty" for the example, because that works with the janitors and is a well-known target state.

