### PR TITLE
Revert "Updated gcp_janitor.py to clean secret manager resources"

### DIFF
--- a/cmd/janitor/gcp_janitor.py
+++ b/cmd/janitor/gcp_janitor.py
@@ -99,12 +99,7 @@ RESOURCES_BY_API = {
                  ['container-analysis-notes-v1', 'container-analysis-notes-v1beta1',
                   'container-analysis-occurrences-v1', 'container-analysis-occurrences-v1beta1'])
     ],
-    
-    #secretmanager resources
-    'secretmanager.googleapis.com': [
-        Resource('', 'secretmanager', 'secrets', None, None,True, False, True, None),
-    ],
-    
+
     # GKE hub memberships
     'gkehub.googleapis.com': [
         Resource('', 'container', 'hub', 'memberships', None, None, False, False, None),


### PR DESCRIPTION
Reverts kubernetes-sigs/boskos#193.

After bumping Boskos janitor version, our projects were stuck in the `cleaning` state. Janitor's logs inspection proves that this PR is at fault here - sample log entry:

```
ERROR: (gcloud) Invalid choice: 'secretmanager'.
Maybe you meant:
  gcloud secrets list
  gcloud secrets locations list
  gcloud secrets versions list
  gcloud ai custom-jobs list
  gcloud ai endpoints list
  gcloud ai hp-tuning-jobs list
  gcloud ai index-endpoints list
  gcloud ai indexes list
  gcloud ai model-monitoring-jobs list
  gcloud ai models list

To search the help text of gcloud commands, run:
  gcloud help -- SEARCH_TERMS
Fail to list resource 'secrets' from project 'gke-scalability-4': CalledProcessError(2, ['gcloud', 'secretmanager', '-q', 'secrets', 'list', '--format=json(name,creationTimestamp.date(tz=UTC),createTime.date(tz=UTC),zone,region,isManaged)', '--project=gke-scalability-4', ...'])
```