### PR TITLE
Add a flag to ignore API key management

### DIFF
--- a/cmd/ibmcloud-janitor-boskos/main.go
+++ b/cmd/ibmcloud-janitor-boskos/main.go
@@ -38,6 +38,7 @@ var (
 	passwordFile = flag.String("password-file", "", "The path to password file used to access the Boskos server")
 	logLevel     = flag.String("log-level", "info", fmt.Sprintf("Log level is one of %v.", logrus.AllLevels))
 	debug        = flag.Bool("debug", false, "Setting it to true allows logs for PowerVS client")
+	ignoreAPIKey = flag.Bool("ignore-api-key", false, "Setting it to true will skip clean up and rotation of API keys")
 )
 
 const (
@@ -60,8 +61,9 @@ func run(boskos *boskosClient.Client) error {
 				return errors.Wrap(err, "Couldn't retrieve resources from Boskos")
 			} else {
 				options := &resources.CleanupOptions{
-					Resource: res,
-					Debug:    *debug,
+					Resource:     res,
+					Debug:        *debug,
+					IgnoreAPIKey: *ignoreAPIKey,
 				}
 				if err := resources.CleanAll(options); err != nil {
 					return errors.Wrapf(err, "Couldn't clean resource %q", res.Name)

--- a/internal/ibmcloud-janitor/resources/clean.go
+++ b/internal/ibmcloud-janitor/resources/clean.go
@@ -18,18 +18,23 @@ package resources
 
 import (
 	"github.com/pkg/errors"
+	"github.com/sirupsen/logrus"
 )
 
 func CleanAll(options *CleanupOptions) error {
 	list, err := listResources(options.Resource.Type)
 	if err != nil {
-		return errors.Wrapf(err, "Failed to fetch the list of resources of type %q", options.Resource.Name)
+		return errors.Wrapf(err, "Failed to fetch the list of resources of type %q", options.Resource.Type)
 	}
 	for _, resource := range list {
 		err = resource.cleanup(options)
 		if err != nil {
-			return errors.Wrapf(err, "Failed to clean the resources of type %q", options.Resource.Type)
+			return errors.Wrapf(err, "Failed to clean the resource %q of type %q", options.Resource.Name, options.Resource.Type)
 		}
+	}
+	if options.IgnoreAPIKey {
+		logrus.Infof("Skipping cleanup and rotation of API keys for resource %s of type %s", options.Resource.Name, options.Resource.Type)
+		return nil
 	}
 
 	for _, resource := range CommonResources {

--- a/internal/ibmcloud-janitor/resources/types.go
+++ b/internal/ibmcloud-janitor/resources/types.go
@@ -34,8 +34,9 @@ type Resource interface {
 }
 
 type CleanupOptions struct {
-	Resource *common.Resource
-	Debug    bool
+	Resource     *common.Resource
+	Debug        bool
+	IgnoreAPIKey bool
 }
 
 var PowervsResources = []Resource{


### PR DESCRIPTION
Add a flag to skip cleanup and rotation of API Keys. This will avoid adding key details to the user data of a resource.

```
# Acquiring resource
./boskosctl acquire --type powervs-service --state free --target-state busy --owner-name amulya --server-url http://localhost:8080 
{"type":"powervs-service","name":"amulya-test-2","state":"busy","owner":"amulya","lastupdate":"2024-10-25T15:27:06.964236+05:30","userdata":{"resource-group":"XXX","service-instance-id":"XXX","zone":"lon04"}}

 ./boskosctl release --name amulya-test-2 --target-state dirty --owner-name amulya --server-url http://localhost:8080                                    
released resource "amulya-test-2"

# Cleanup using janitor
go run cmd/ibmcloud-janitor-boskos/main.go --boskos-url=http://localhost:8080 -ignore-api-key=true -resource-type powervs-service 
{"component":"unset","file":"/Users/amulyameka/go/src/github.com/boskos/internal/ibmcloud-janitor/resources/powervs_instances.go:46","func":"sigs.k8s.io/boskos/internal/ibmcloud-janitor/resources.PowerVSInstance.cleanup","level":"info","msg":"Cleaning up the virtual server instances","resource":"amulya-test-2","severity":"info","time":"2024-10-25T15:37:15+05:30"}
{"component":"unset","file":"/Users/amulyameka/go/src/github.com/boskos/internal/ibmcloud-janitor/resources/powervs_client.go:103","func":"sigs.k8s.io/boskos/internal/ibmcloud-janitor/resources.NewPowerVSClient","level":"info","msg":"successfully created PowerVS client","resource":"amulya-test-2","severity":"info","time":"2024-10-25T15:37:15+05:30"}

{"component":"unset","file":"/Users/amulyameka/go/src/github.com/boskos/internal/ibmcloud-janitor/resources/powervs_instances.go:63","func":"sigs.k8s.io/boskos/internal/ibmcloud-janitor/resources.PowerVSInstance.cleanup","level":"info","msg":"Successfully deleted virtual server instances","resource":"amulya-test-2","severity":"info","time":"2024-10-25T15:37:17+05:30"}
{"component":"unset","file":"/Users/amulyameka/go/src/github.com/boskos/internal/ibmcloud-janitor/resources/powervs_networks.go:46","func":"sigs.k8s.io/boskos/internal/ibmcloud-janitor/resources.PowerVSNetwork.cleanup","level":"info","msg":"Cleaning up the networks","resource":"amulya-test-2","severity":"info","time":"2024-10-25T15:37:17+05:30"}
{"component":"unset","file":"/Users/amulyameka/go/src/github.com/boskos/internal/ibmcloud-janitor/resources/powervs_client.go:103","func":"sigs.k8s.io/boskos/internal/ibmcloud-janitor/resources.NewPowerVSClient","level":"info","msg":"successfully created PowerVS client","resource":"amulya-test-2","severity":"info","time":"2024-10-25T15:37:18+05:30"}

{"component":"unset","file":"/Users/amulyameka/go/src/github.com/boskos/internal/ibmcloud-janitor/resources/powervs_networks.go:73","func":"sigs.k8s.io/boskos/internal/ibmcloud-janitor/resources.PowerVSNetwork.cleanup","level":"info","msg":"Successfully deleted the networks","resource":"amulya-test-2","severity":"info","time":"2024-10-25T15:37:19+05:30"}
{"component":"unset","file":"/Users/amulyameka/go/src/github.com/boskos/internal/ibmcloud-janitor/resources/clean.go:36","func":"sigs.k8s.io/boskos/internal/ibmcloud-janitor/resources.CleanAll","level":"info","msg":"Skipping cleanup and rotation of API keys for resource amulya-test-2 of type powervs-service","severity":"info","time":"2024-10-25T15:37:19+05:30"}
{"component":"unset","file":"/Users/amulyameka/go/src/github.com/boskos/cmd/ibmcloud-janitor-boskos/main.go:77","func":"main.run","level":"info","msg":"Released resource","name":"amulya-test-2","severity":"info","time":"2024-10-25T15:37:19+05:30"}
```