### PR TITLE
Clean up secrets created during the tests.

### DIFF
--- a/cmd/janitor/gcp_janitor.py
+++ b/cmd/janitor/gcp_janitor.py
@@ -617,7 +617,7 @@ def clean_secrets(project, age, filt):
         created = datetime.datetime.strptime(
             item['createTime'][:19], '%Y-%m-%dT%H:%M:%S')
         if created < age:
-            log('Found stale gke cluster %r, created time = %r' %
+            log('Found stale secret %r, created time = %r' %
                 (item['name'], item['createTime']))
             delete = [
                 'gcloud', 'secrets', '-q', 'delete',


### PR DESCRIPTION
I am working on-recreating a prow job and these prow jobs deleted during migration to community infra. [Discussion ref](https://groups.google.com/a/kubernetes.io/g/dev/c/p6PAML90ZOU).

I am re-enabling this [job](https://github.com/kubernetes/test-infra/blob/master/config/jobs/kubernetes-sigs/secrets-store-csi-driver/secrets-store-csi-driver-config.yaml#L682-L725) to run on community infra. 
To run the job in community infra, I need to create secrets from google secret manager.

This PR is to remove secrets created during the job execution.