### PR TITLE
Complete migration to AWS Go client V2.

### DIFF
--- a/aws-janitor/resources/clean.go
+++ b/aws-janitor/resources/clean.go
@@ -20,7 +20,7 @@ import (
 	"net/http"
 	"strings"
 
-	"github.com/aws/aws-sdk-go/aws/awserr"
+	awshttp "github.com/aws/aws-sdk-go-v2/aws/transport/http"
 
 	"github.com/pkg/errors"
 	"github.com/sirupsen/logrus"
@@ -47,8 +47,11 @@ func CleanAll(opts Options, region string) error {
 			set, err := typ.ListAll(opts)
 			if err != nil {
 				// ignore errors for resources we do not have permissions to list
-				if reqerr, ok := errors.Cause(err).(awserr.RequestFailure); ok {
-					if reqerr.StatusCode() == http.StatusForbidden {
+				if resperr, ok := errors.Cause(err).(*awshttp.ResponseError); ok {
+					var responseError interface {
+					    HTTPStatusCode() int
+					}
+					if resperr.As(&responseError) && responseError.HTTPStatusCode() == http.StatusForbidden {
 						logger.Debugf("Skipping resources of type %T, account does not have permission to list", typ)
 						continue
 					}

--- a/aws-janitor/resources/s3_bucket.go
+++ b/aws-janitor/resources/s3_bucket.go
@@ -52,8 +52,8 @@ func (S3Bucket) MarkAndSweep(opts Options, set *Set) error {
 		opt.Region = opts.Region
 	})
 
-	// ListBucket lists all buckets owned by the authenticated sender of the request
-	// https://pkg.go.dev/github.com/aws/aws-sdk-go/service/s3#S3.ListBuckets
+	// ListBuckets lists all buckets owned by the authenticated sender of the request
+	// https://pkg.go.dev/github.com/aws/aws-sdk-go-v2/service/s3#Client.ListBuckets
 	// regardless the region configured in client.
 	resp, err := svc.ListBuckets(context.TODO(), &s3v2.ListBucketsInput{})
 	if err != nil {
@@ -130,8 +130,8 @@ func (S3Bucket) ListAll(opts Options) (*Set, error) {
 		opt.Region = opts.Region
 	})
 
-	// ListBucket lists all buckets owned by the authenticated sender of the request
-	// https://pkg.go.dev/github.com/aws/aws-sdk-go/service/s3#S3.ListBuckets
+	// ListBuckets lists all buckets owned by the authenticated sender of the request
+	// https://pkg.go.dev/github.com/aws/aws-sdk-go-v2/service/s3#Client.ListBuckets
 	// regardless the region configured in client.
 	resp, err := svc.ListBuckets(context.TODO(), &s3v2.ListBucketsInput{})
 	if err != nil {


### PR DESCRIPTION
This is in response to https://github.com/kubernetes-sigs/boskos/issues/196
This PR eliminates the remaining few references to github.com/aws/aws-sdk-go/aws/ - even from the comments.