### PR TITLE
Build and push multi-arch images for platform s390x

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -41,7 +41,7 @@ CONTROLLER_GEN := $(TOOLS_BIN_DIR)/$(CONTROLLER_GEN_BIN)-$(CONTROLLER_GEN_VER)
 CONTAINER_ENGINE := $(if $(shell which docker),docker,$(if $(shell which podman),podman,))
 
 CMDS = $(notdir $(shell find ./cmd/ -maxdepth 1 -type d | sort))
-MULTI_ARCH_PLATFORMS = linux/amd64,linux/arm64,linux/ppc64le
+MULTI_ARCH_PLATFORMS = linux/amd64,linux/arm64,linux/ppc64le,linux/s390x
 
 export GO_VERSION=1.23.4
 export GO111MODULE=on

--- a/images/build.sh
+++ b/images/build.sh
@@ -20,7 +20,7 @@ set -o errexit
 set -o nounset
 set -o pipefail
 
-multi_arch_platforms="linux/amd64,linux/arm64,linux/ppc64le"
+multi_arch_platforms="linux/amd64,linux/arm64,linux/ppc64le,linux/s390x"
 
 if [[ -z "${DOCKER_REPO:-}" ]]; then
     echo "DOCKER_REPO must be set!" >&2


### PR DESCRIPTION
This PR adds changes for enabling multi arch build for boskos images for s390x platform.

Issue: https://github.com/kubernetes-sigs/boskos/issues/221