### PR TITLE
Add a flag to pass account ID in ibmcloud-janitor

### DIFF
--- a/cmd/ibmcloud-janitor-boskos/main.go
+++ b/cmd/ibmcloud-janitor-boskos/main.go
@@ -39,6 +39,7 @@ var (
 	logLevel     = flag.String("log-level", "info", fmt.Sprintf("Log level is one of %v.", logrus.AllLevels))
 	debug        = flag.Bool("debug", false, "Setting it to true allows logs for PowerVS client")
 	ignoreAPIKey = flag.Bool("ignore-api-key", false, "Setting it to true will skip clean up and rotation of API keys")
+	accountID    = flag.String("accound-id", "", "ID of the IBM Cloud account")
 )
 
 const (
@@ -64,6 +65,9 @@ func run(boskos *boskosClient.Client) error {
 					Resource:     res,
 					Debug:        *debug,
 					IgnoreAPIKey: *ignoreAPIKey,
+				}
+				if accountID != nil {
+					options.AccountID = accountID
 				}
 				if err := resources.CleanAll(options); err != nil {
 					return errors.Wrapf(err, "Couldn't clean resource %q", res.Name)

--- a/internal/ibmcloud-janitor/resources/powervs_client.go
+++ b/internal/ibmcloud-janitor/resources/powervs_client.go
@@ -68,6 +68,7 @@ func (p *IBMPowerVSClient) DeletePort(networkID, portID string) error {
 
 // Returns a new PowerVS client
 func NewPowerVSClient(options *CleanupOptions) (*IBMPowerVSClient, error) {
+	var accountID *string
 	resourceLogger := logrus.WithFields(logrus.Fields{"resource": options.Resource.Name})
 	pclient := &IBMPowerVSClient{}
 	powervsData, err := ibmcloud.GetPowerVSResourceData(options.Resource)
@@ -85,16 +86,20 @@ func NewPowerVSClient(options *CleanupOptions) (*IBMPowerVSClient, error) {
 		return nil, errors.Wrap(err, "failed to create serviceID client")
 	}
 
-	account, err := sclient.GetAccount()
-	if err != nil {
-		return nil, errors.Wrap(err, "failed to get the account")
+	if options.AccountID != nil {
+		accountID = options.AccountID
+	} else {
+		accountID, err = sclient.GetAccount()
+		if err != nil {
+			return nil, errors.Wrap(err, "failed to get the account ID")
+		}
 	}
 
 	clientOptions := &ibmpisession.IBMPIOptions{
 		Debug:         options.Debug,
 		Authenticator: auth,
 		Zone:          powervsData.Zone,
-		UserAccount:   *account,
+		UserAccount:   *accountID,
 	}
 	pclient.session, err = ibmpisession.NewIBMPISession(clientOptions)
 	if err != nil {

--- a/internal/ibmcloud-janitor/resources/serviceid.go
+++ b/internal/ibmcloud-janitor/resources/serviceid.go
@@ -40,9 +40,9 @@ func getAPIkeyName() string {
 }
 
 // Lists and returns the target service ID
-func (s *ServiceID) fetchServiceID(account *string) (*identityv1.ServiceID, error) {
+func (s *ServiceID) fetchServiceID(accountID *string) (*identityv1.ServiceID, error) {
 	options := &identityv1.ListServiceIdsOptions{
-		AccountID: account,
+		AccountID: accountID,
 		Name:      &s.key.serviceIDName,
 	}
 
@@ -96,6 +96,7 @@ func (s *ServiceID) resetKeys(serviceID *identityv1.ServiceID) (*identityv1.APIK
 }
 
 func (k APIKey) cleanup(options *CleanupOptions) error {
+	var accountID *string
 	resourceLogger := logrus.WithFields(logrus.Fields{"resource": options.Resource.Name})
 	resourceLogger.Info("Cleaning up the API key of resource")
 
@@ -109,12 +110,16 @@ func (k APIKey) cleanup(options *CleanupOptions) error {
 		return errors.Wrap(err, "failed to create serviceID client")
 	}
 
-	account, err := sclient.GetAccount()
-	if err != nil {
-		return errors.Wrap(err, "failed to get the account ID")
+	if options.AccountID != nil {
+		accountID = options.AccountID
+	} else {
+		accountID, err = sclient.GetAccount()
+		if err != nil {
+			return errors.Wrap(err, "failed to get the account ID")
+		}
 	}
 
-	serviceID, err := sclient.fetchServiceID(account)
+	serviceID, err := sclient.fetchServiceID(accountID)
 	if err != nil {
 		return errors.Wrap(err, "failed to fetch Service ID")
 	}

--- a/internal/ibmcloud-janitor/resources/types.go
+++ b/internal/ibmcloud-janitor/resources/types.go
@@ -37,6 +37,7 @@ type CleanupOptions struct {
 	Resource     *common.Resource
 	Debug        bool
 	IgnoreAPIKey bool
+	AccountID    *string
 }
 
 var PowervsResources = []Resource{


### PR DESCRIPTION
This PR adds a flag to pass account ID as a flag and use it or fetch the account ID using the API key.