### PR TITLE
Janitor Cleanup Based on VPC ID

### DIFF
--- a/common/ibmcloud/common.go
+++ b/common/ibmcloud/common.go
@@ -40,6 +40,7 @@ type PowerVSResourceData struct {
 type VPCResourceData struct {
 	Region        string
 	ResourceGroup string
+	VPCID         string
 }
 
 // Fetches the resource user data for type powervs-service
@@ -78,11 +79,17 @@ func GetVPCResourceData(r *common.Resource) (*VPCResourceData, error) {
 	if !ok {
 		return nil, errors.New("no resource group in UserData")
 	}
-
-	return &VPCResourceData{
+	data := &VPCResourceData{
 		Region:        region.(string),
 		ResourceGroup: rg.(string),
-	}, nil
+	}
+
+	// Optional VPC ID
+	if vpcID, ok := r.UserData.Map.Load("vpc-id"); ok {
+		data.VPCID = vpcID.(string)
+	}
+
+	return data, nil
 }
 
 // Updates user data of the resource

--- a/internal/ibmcloud-janitor/resources/vpc.go
+++ b/internal/ibmcloud-janitor/resources/vpc.go
@@ -34,6 +34,12 @@ func (VPCs) cleanup(options *CleanupOptions) error {
 		return errors.Wrap(err, "couldn't create VPC client")
 	}
 
+	// Skip VPC deletion if specific VPC ID is provided
+	if client.VPCID != "" {
+		resourceLogger.Info("Skipping VPC deletion as VPC ID is passed in user-data")
+		return nil
+	}
+
 	vpcList, _, err := client.ListVpcs(&vpcv1.ListVpcsOptions{
 		ResourceGroupID: &client.ResourceGroupID,
 	})

--- a/internal/ibmcloud-janitor/resources/vpc_client.go
+++ b/internal/ibmcloud-janitor/resources/vpc_client.go
@@ -31,6 +31,7 @@ import (
 type IBMVPCClient struct {
 	vpcService      *vpcv1.VpcV1
 	ResourceGroupID string
+	VPCID           string
 	Resource        *common.Resource
 }
 
@@ -90,6 +91,10 @@ func (c *IBMVPCClient) GetLoadBalancer(options *vpcv1.GetLoadBalancerOptions) (r
 	return c.vpcService.GetLoadBalancer(options)
 }
 
+func (c *IBMVPCClient) GetSubnet(options *vpcv1.GetSubnetOptions) (*vpcv1.Subnet, *core.DetailedResponse, error) {
+	return c.vpcService.GetSubnet(options)
+}
+
 // Creates a new VPC Client
 func NewVPCClient(options *CleanupOptions) (*IBMVPCClient, error) {
 	client := &IBMVPCClient{}
@@ -100,6 +105,7 @@ func NewVPCClient(options *CleanupOptions) (*IBMVPCClient, error) {
 	}
 
 	client.ResourceGroupID = vpcData.ResourceGroup
+	client.VPCID = vpcData.VPCID
 	client.Resource = options.Resource
 	url := "https://" + vpcData.Region + ".iaas.cloud.ibm.com/v1"
 	auth, err := account.GetAuthenticator()

--- a/internal/ibmcloud-janitor/resources/vpc_instances.go
+++ b/internal/ibmcloud-janitor/resources/vpc_instances.go
@@ -34,9 +34,15 @@ func (VPCInstance) cleanup(options *CleanupOptions) error {
 		return errors.Wrap(err, "couldn't create VPC client")
 	}
 
-	instanceList, _, err := client.ListInstances(&vpcv1.ListInstancesOptions{
+	// List instances with optional VPC filter
+	listInstanceOpts := &vpcv1.ListInstancesOptions{
 		ResourceGroupID: &client.ResourceGroupID,
-	})
+	}
+	if client.VPCID != "" {
+		listInstanceOpts.VPCID = &client.VPCID
+	}
+
+	instanceList, _, err := client.ListInstances(listInstanceOpts)
 	if err != nil {
 		return errors.Wrap(err, "failed to list the instances")
 	}


### PR DESCRIPTION
Enhances the IBM Cloud Janitor functionality to support resource cleanup based on a specific VPC ID.

Changes Introduced:
- Added conditional logic to clean up resources (subnets, floating IPs, load balancers) based on the VPC they are associated with.
- When `vpc-id` is passed in the API call, the janitor filters and deletes:
  - Subnets within the specified VPC
  - Unbound floating IPs (with conditional checks if VPC is specified)
  - Load balancers attached to subnets belonging to the specified VPC
- If `vpc-id` is not provided, the cleanup falls back to using the resource group as the default filter.

Why:
This allows more granular and targeted cleanup, especially useful when multiple VPCs exist under the same resource group.