### PR TITLE
Increase timeout for image build

### DIFF
--- a/images/cloudbuild.yaml
+++ b/images/cloudbuild.yaml
@@ -16,7 +16,7 @@
 # See https://cloud.google.com/cloud-build/docs/build-config for more details.
 
 # This must be specified in seconds. If omitted, defaults to 600s (10 mins)
-timeout: 1500s
+timeout: 3600s
 # This prevents errors if you don't use both _GIT_TAG and _PULL_BASE_REF,
 # or any new substitutions added in the future.
 options:


### PR DESCRIPTION
The boskos images build has been timing out, this PR increases the timeout to 3600s.