### PR TITLE
Proposed a release process for the Boskos project

### DIFF
--- a/RELEASE.md
+++ b/RELEASE.md
@@ -1,0 +1,47 @@
+# Boskos Release Process
+This document outlines the procedure for creating a new release for the Boskos project. Following these steps ensures that release tags are correctly associated with their corresponding container images and that those images are promoted to the official registry.
+
+## Step 1: Tag the Release Commit
+First, identify the commit you intend to release. Create a new semantic version tag for this commit, incrementing the patch version from the previous release.
+
+Create the tag locally:
+
+`git tag vX.Y.Z <your-commit-hash>`
+
+(Replace `vX.Y.Z` with the new version number, e.g., `v0.0.1`)
+
+Push the new tag to the repo:
+
+`git push origin vX.Y.Z`
+
+## Step 2: Verify Container Images
+Next, confirm that all required container images for the tagged commit have been successfully built and pushed to the staging container registry, this is done by a postsubmit Prow job automatically.
+
+Execute the `check_images.sh` script, providing the first 7 characters of your release commit's hash as an argument.
+
+`./hack/check_images.sh <7-char-commit-hash>`
+
+## Step 3: Review Verification Results
+The outcome of the script determines the next action.
+
+✅ On Success: If the script completes successfully, it will print the SHA digest for each container image to the console.
+
+❌ On Failure: If the script fails, it means one or more images are not present in the staging repository. You need to investigate the cause of the build failure before proceeding.
+
+> **Troubleshooting**: Visit the [post-boskos-push-images](https://prow.k8s.io/job-history/gs/kubernetes-ci-logs/logs/post-boskos-push-images) job history on Prow to find the failed build job and view its logs to diagnose the problem.
+
+## Step 4: Update the Image Registry File
+With the new version tag and image digests, you must update the central image manifest in the kubernetes/k8s.io repository.
+
+Clone the [kubernetes/k8s.io](https://github.com/kubernetes/k8s.io/tree/main) repository if you don't have it locally.
+
+Open the following file for editing: registry.k8s.io/images/k8s-staging-boskos/images.yaml
+
+Add the image hashes to the file, associating them with the semver tag you created in Step 1.
+
+Create a Pull Request with your changes to the kubernetes/k8s.io repository.
+
+## Step 5: Wait for Image Promotion
+After your Pull Request is reviewed and merged, the process is nearly complete.
+
+The final step is to wait for the image promotion process, which is handled by [automation](https://github.com/kubernetes/k8s.io/tree/main/registry.k8s.io#image-promoter). Once the promotion is finished, the release is officially live.

--- a/hack/check_images.sh
+++ b/hack/check_images.sh
@@ -1,0 +1,68 @@
+#!/usr/bin/env bash
+# Copyright 2025 The Kubernetes Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+set -o errexit
+set -o nounset
+set -o pipefail
+
+REPO="gcr.io/k8s-staging-boskos"
+
+# Check if a commit SHA was provided as a command-line argument
+if [ -z "$1" ]; then
+  echo "Usage: $0 <last_7_chars_commit_sha>"
+  echo "Please provide the last 7 chars of the commit hash to search for in the image tags."
+  exit 1
+fi
+
+COMMIT_SHA="$1"
+
+# Get a list of all images in the specified repository
+images=$(gcloud container images list --repository="$REPO" --format="get(name)")
+expected_count=$(echo $images | wc -w | tr -d ' ')
+echo "There are $expected_count distinct Boskos images in total"
+
+# This should not happen.
+if [ -z "$images" ]; then
+  echo "No images found in repository: $REPO"
+  exit 1
+fi
+
+echo "Searching for tags containing '$COMMIT_SHA' in repository '$REPO'..."
+echo "---"
+
+matched_count=0
+
+printf "%-70s %s\n" "IMAGE_NAME" "MATCHED_IMAGE_SHA256"
+for image in $images; do
+  # Find the images whose tags match the commit hash
+  digest=$(gcloud container images list-tags "$image" --filter="tags~$COMMIT_SHA" --format="get(digest)")
+
+  # If any tags matched, add the image to our list of matches
+  if [ -n "$digest" ]; then
+    printf "%-70s %s\n" "$image" "$digest"
+    ((matched_count += 1))
+  fi
+done
+
+echo "Validation completed."
+echo "Found $matched_count images with matching tags."
+
+if [ "$matched_count" -eq "$expected_count" ]; then
+  echo "✅ Success: The number of matched images is exactly $expected_count."
+  exit 0
+else
+  echo "❌ Failure: Expected $expected_count images, but found $matched_count."
+  exit 1
+fi


### PR DESCRIPTION
Re: Issue #218 

This PR proposes a lightweight release process for the Boskos project.

The script in this PR helps search and fetch the container image hashes for the images built from a given commit.

Note that the `registry.k8s.io/images/k8s-staging-boskos/images.yaml` doesn't exist in the `kubernetes/k8s.io` repo just yet because we need to have the first version tag (probably `v0.0.1` to commit `e9e5322`) in this repo before we map that version tag to the first set of images in the image promoter.