### PR TITLE
Fix ibmcloud-janitor restart on cleanup failure issue

### DIFF
--- a/cmd/ibmcloud-janitor-boskos/main.go
+++ b/cmd/ibmcloud-janitor-boskos/main.go
@@ -74,7 +74,8 @@ func run(boskos *boskosClient.Client) error {
 			}
 			options.Resource = res
 			if err := resources.CleanAll(options); err != nil {
-				return errors.Wrapf(err, "Failed to clean resource %q", res.Name)
+				logrus.WithError(err).Errorf("Failed to clean resource %q", res.Name)
+				continue
 			}
 			if err := boskos.UpdateOne(res.Name, common.Cleaning, res.UserData); err != nil {
 				return errors.Wrapf(err, "Failed to update resource %q", res.Name)


### PR DESCRIPTION
### **Issue and root cause:**
Janitor was restarting whenever a cleanup operation failed.The janitor process was using a return statement inside its infinite loop to handle cleanup failures. This caused the loop to exit gracefully whenever a cleanup error occurred, leading to premature termination of the janitor service.

### **Fix:**
Instead of returning the error, logged the error and continue to ensure the loop keeps running even after cleanup failures.

### **Test:**
Confirmed that cleanup errors are logged and the loop continues without triggering a restart.

<img width="1114" height="506" alt="Screenshot 2025-09-18 at 2 54 33 PM" src="https://github.com/user-attachments/assets/7607db70-6e23-44a5-8a25-cefd75bb8353" />