### PR TITLE
Shield lustre-network subnet from deletion

### DIFF
--- a/cmd/janitor/gcp_janitor.py
+++ b/cmd/janitor/gcp_janitor.py
@@ -29,6 +29,7 @@ import threading
 # Lustre CSI Constants
 LUSTRE_REGEX = 'lustre-.*'
 LUSTRE_MULTINIC_SUBNET = 'multinic-subnet'
+LUSTRE_SUBNET = "lustre-network"
 
 # A resource that need to be cleared.
 # Any names in preserved_names will never be deleted.
@@ -479,7 +480,7 @@ def clean_secondary_ip_ranges(project, age, filt):
 
     # List secondary address rangeds
     for subnet in subnets:
-        if subnet.name in [LUSTRE_MULTINIC_SUBNET]:
+        if subnet.name in [LUSTRE_MULTINIC_SUBNET, LUSTRE_SUBNET]:
             log('Skip default subnet %s in region %s' % (subnet.name, subnet.region))
             continue
         log('Describing subnets')


### PR DESCRIPTION
Recently we had some bugs open due to a failed attempt by the boskos janitor to delete the subnet `lustre-network`, this is due to a bug in https://github.com/kubernetes-sigs/boskos/pull/244 where we only delete the multi nic subnet. This failure to shield `lustre-network` means that the boskos janitor WILL attempt to delete the subnet but the subnet is still in use by other resources which HAVE been shielded, which results in a failure. 

This bug adresses this issue by correctly blocking the deletion of the`lustre-network` subnet.
