### PR TITLE
preserve lustre network resourses by checking network

### DIFF
--- a/cmd/janitor/gcp_janitor.py
+++ b/cmd/janitor/gcp_janitor.py
@@ -267,6 +267,14 @@ def validate_item(item, age, resource, clear_all):
     # clears everything without checking creationTimestamp
     if clear_all:
         return True
+    
+    if resource.name in ['subnets', 'routes'] and 'network' in item:
+        # The network field is a URL like: 
+        # https://www.googleapis.com/compute/v1/projects/my-proj/global/networks/my-network
+        network_name = item['network'].rsplit('/', 1)[-1]
+        if network_name in [LUSTRE_SUBNET]:
+            log('Skipping subnet %s because it belongs to protected network %s' % (item['name'], network_name))
+            return False
 
     creationTimestamp = item.get('creationTimestamp', item.get('createTime'))
     if creationTimestamp is None:
@@ -310,7 +318,7 @@ def collect(project, zones, age, resource, filt, clear_all):
     cmd = base_command(resource)
     cmd.extend([
         'list',
-        '--format=json(name,creationTimestamp.date(tz=UTC),createTime.date(tz=UTC),zone,region,isManaged)',
+        '--format=json(name,creationTimestamp.date(tz=UTC),createTime.date(tz=UTC),zone,region,isManaged,network)',
         '--project=%s' % project])
     if (resource.condition == 'zone'
             and resource.name != 'sole-tenancy'


### PR DESCRIPTION
This PR adds a skip for networking resources that are in lustre networks. Currently there are Lustre routes and subnets lingering which should be exempt from deletion but the janitor still tries to delete them which is not allowed This preservation of the Lustre network is a change introduced in https://github.com/kubernetes-sigs/boskos/pull/244. The change is crucial to fixing our Boskos project rental system.

Cleanups worked correctly before because deleting the entire VPC network was a "catch-all" operation that bypassed these restrictions. Now that the network is retained, the Janitor must be taught to ignore the sub-resources that GCP prevents us from deleting manually.This PR adds a skip for networking resources that are lingering due to lustre networks which created them no longer being deleted during the janitor script. This preservation of the lustre network is a change introduced in https://github.com/kubernetes-sigs/boskos/pull/244. The change is crucial to fixing our boskos project rental system.

Cleanups worked correctly before because deleting the entire VPC network was a "catch-all" operation that bypassed these restrictions. Now that the network is retained, the Janitor must be taught to ignore the sub-resources that GCP prevents us from deleting manually.