### PR TITLE
Revert "Add Lustre instance cleanup to Boskos GCP Janitor"

### DIFF
--- a/cmd/janitor/gcp_janitor.py
+++ b/cmd/janitor/gcp_janitor.py
@@ -49,17 +49,6 @@ RESOURCES_BY_API = {
         Resource('alpha', 'parallelstore', 'instances', None, 'location', None, False, False, None),
     ],
 
-    # lustre resources
-    'lustre.googleapis.com': [
-        Resource('', 'lustre', 'instances', None, 'location', None, False, False, None),
-    ],
-    'staging-lustre.sandbox.googleapis.com': [
-        Resource('', 'lustre', 'instances', None, 'location', None, False, False, None),
-    ],
-    'autopush-lustre.sandbox.googleapis.com': [
-        Resource('', 'lustre', 'instances', None, 'location', None, False, False, None),
-    ],
-
     # compute resources
     'compute.googleapis.com': [
         Resource('', 'compute', 'instances', None, 'zone', None, False, True, None),
@@ -344,7 +333,7 @@ def collect(project, zones, age, resource, filt, skip_age_check):
         cmd.append('--filter=%s AND zone:( %s )' % (filt, ' '.join(zones)))
     else:
         cmd.append('--filter=%s' % filt)
-    if resource.group in ('parallelstore', 'lustre'):
+    if (resource.group == 'parallelstore'):
         cmd.append('--location=-')
     log('%r' % cmd)
 
@@ -381,8 +370,8 @@ def collect(project, zones, age, resource, filt, skip_age_check):
                 # Filestore instances don't have 'zone' field, but require
                 # --zone flag for deletion.
                 colname = item['name'].split('/')[3]
-            elif resource.group in ('parallelstore', 'lustre'):
-                # Parallelstore/Lustre instances don't have 'location' field, but require
+            elif resource.group == 'parallelstore':
+                # Parallelstore instances don't have 'location' field, but require
                 # --location flag for deletion.
                 colname = item['name'].split('/')[3]
             else:


### PR DESCRIPTION
This reverts commit 547096eb22f50ef28c1e21ff124bbbb196be0106.

Adding the change resulted in failure to run gcloud lustre commands due to old version of gcloud-sdk 