### PR TITLE
Add Lustre instance cleanup to Boskos GCP Janitor

### DIFF
--- a/cmd/janitor/gcp_janitor.py
+++ b/cmd/janitor/gcp_janitor.py
@@ -49,6 +49,17 @@ RESOURCES_BY_API = {
         Resource('alpha', 'parallelstore', 'instances', None, 'location', None, False, False, None),
     ],
 
+    # lustre resources
+    'lustre.googleapis.com': [
+        Resource('', 'lustre', 'instances', None, 'location', None, False, False, None),
+    ],
+    'staging-lustre.sandbox.googleapis.com': [
+        Resource('', 'lustre', 'instances', None, 'location', None, False, False, None),
+    ],
+    'autopush-lustre.sandbox.googleapis.com': [
+        Resource('', 'lustre', 'instances', None, 'location', None, False, False, None),
+    ],
+
     # compute resources
     'compute.googleapis.com': [
         Resource('', 'compute', 'instances', None, 'zone', None, False, True, None),
@@ -333,7 +344,7 @@ def collect(project, zones, age, resource, filt, skip_age_check):
         cmd.append('--filter=%s AND zone:( %s )' % (filt, ' '.join(zones)))
     else:
         cmd.append('--filter=%s' % filt)
-    if (resource.group == 'parallelstore'):
+    if resource.group in ('parallelstore', 'lustre'):
         cmd.append('--location=-')
     log('%r' % cmd)
 
@@ -370,8 +381,8 @@ def collect(project, zones, age, resource, filt, skip_age_check):
                 # Filestore instances don't have 'zone' field, but require
                 # --zone flag for deletion.
                 colname = item['name'].split('/')[3]
-            elif resource.group == 'parallelstore':
-                # Parallelstore instances don't have 'location' field, but require
+            elif resource.group in ('parallelstore', 'lustre'):
+                # Parallelstore/Lustre instances don't have 'location' field, but require
                 # --location flag for deletion.
                 colname = item['name'].split('/')[3]
             else:

--- a/cmd/janitor/gcp_janitor.py
+++ b/cmd/janitor/gcp_janitor.py
@@ -50,6 +50,7 @@ RESOURCES_BY_API = {
     ],
 
     # lustre resources
+    # "gcloud lustre" commands require gcloud version 519.0.0 and above (April 2025)
     'lustre.googleapis.com': [
         Resource('', 'lustre', 'instances', None, 'location', None, False, False, None),
     ],

--- a/images/janitor/Dockerfile
+++ b/images/janitor/Dockerfile
@@ -35,7 +35,7 @@ RUN make build
 ARG cmd
 RUN make "${cmd}"
 
-FROM gcr.io/google.com/cloudsdktool/cloud-sdk:462.0.1-slim
+FROM gcr.io/google.com/cloudsdktool/cloud-sdk:568.0.0-slim
 COPY ./cmd/janitor/gcp_janitor.py /bin
 
 ARG cmd


### PR DESCRIPTION
Clean up Lustre instances to prevent resource leakage. Additionally, bump `gcloud` to a newer version. The previous version, `462.0.1`, is over two years old and does not support `gcloud lustre` operations. (This version change is based on PR #253.)

This PR is an updated version of the reverted PR #252, which failed to bump the `gcloud` version and therefore led to cleanup failures with error: `ERROR: (gcloud) Invalid choice: 'lustre'.`

### Testing

I verified the updated script works on my own project:
```
adinilfeld@adinilfeld:~/src/lustre-csi-driver$  /usr/local/google/home/adinilfeld/src/boskos/cmd/janitor/gcp_janitor.py     --project=adinilfeld-gke-dev     --days=0     --hours=0     --dryrun     --verbose
...
[2026-05-08 00:10:09.282597] [DRYRUN] Call ['gcloud', 'lustre', '-q', 'instances', 'delete', '--project=adinilfeld-gke-dev', 'projects/adinilfeld-gke-dev/locations/us-central1-a/instances/dummy-lustre-1', '--location=us-central1-a']
...
[=== Finish Janitor on project 'adinilfeld-gke-dev' with status 0 ===]
```
And when I run the outputted command manually, it works:
```
adinilfeld@adinilfeld:~/src/lustre-csi-driver$ gcloud lustre -q instances delete --project=adinilfeld-gke-dev projects/adinilfeld-gke-dev/locations/us-central1-a/instances/dummy-lustre-1 --location=us-central1-a
Delete request issued for: [dummy-lustre-1]
Waiting for operation [projects/adinilfeld-gke-dev/locations/us-central1-a/operatio
ns/operation-1778200045070-651437606a98f-9147dd64-5555c3a3] to complete...done.
Deleted instance [dummy-lustre-1].
```

