### PR TITLE
Add FSx for Lustre cleanup

### DIFF
--- a/aws-janitor/resources/fsx.go
+++ b/aws-janitor/resources/fsx.go
@@ -1,0 +1,180 @@
+/*
+Copyright 2026 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package resources
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	"github.com/aws/aws-sdk-go-v2/aws"
+	"github.com/aws/aws-sdk-go-v2/service/fsx"
+	fsxtypes "github.com/aws/aws-sdk-go-v2/service/fsx/types"
+
+	"github.com/pkg/errors"
+	"github.com/sirupsen/logrus"
+)
+
+type fsxClient interface {
+	DescribeFileSystems(ctx context.Context, params *fsx.DescribeFileSystemsInput, optFns ...func(*fsx.Options)) (*fsx.DescribeFileSystemsOutput, error)
+	DeleteFileSystem(ctx context.Context, params *fsx.DeleteFileSystemInput, optFns ...func(*fsx.Options)) (*fsx.DeleteFileSystemOutput, error)
+}
+
+// FSxLustreFileSystems manages only FSx for Lustre file systems. Other FSx
+// families have different deletion prerequisites and backup behavior.
+type FSxLustreFileSystems struct{}
+
+func (FSxLustreFileSystems) MarkAndSweep(opts Options, set *Set) error {
+	svc := fsx.NewFromConfig(*opts.Config, func(opt *fsx.Options) {
+		opt.Region = opts.Region
+	})
+	return markAndSweepFSxLustreFileSystems(svc, opts, set)
+}
+
+func markAndSweepFSxLustreFileSystems(svc fsxClient, opts Options, set *Set) error {
+	logger := logrus.WithField("options", opts)
+	fileSystems, err := describeFSxFileSystems(svc)
+	if err != nil {
+		return errors.Wrapf(err, "couldn't describe FSx file systems for %q in %q", opts.Account, opts.Region)
+	}
+
+	// Finish discovery before issuing deletions so a pagination failure cannot
+	// leave the account only partially swept.
+	toDelete := make([]*fsxLustreFileSystem, 0, len(fileSystems))
+	for _, description := range fileSystems {
+		if description.FileSystemType != fsxtypes.FileSystemTypeLustre {
+			continue
+		}
+
+		fileSystem, err := newFSxLustreFileSystem(description)
+		if err != nil {
+			return err
+		}
+		tags, err := fromFSxTags(description.Tags)
+		if err != nil {
+			return fmt.Errorf("%s: invalid tags: %w", fileSystem.ARN(), err)
+		}
+		if !set.Mark(opts, fileSystem, description.CreationTime, tags) {
+			continue
+		}
+		if description.Lifecycle == fsxtypes.FileSystemLifecycleDeleting {
+			logger.Infof("%s: already deleting", fileSystem.ARN())
+			continue
+		}
+
+		logger.Warningf("%s: deleting %T: %s", fileSystem.ARN(), description, fileSystem.id)
+		if !opts.DryRun {
+			toDelete = append(toDelete, fileSystem)
+		}
+	}
+
+	for _, fileSystem := range toDelete {
+		input := &fsx.DeleteFileSystemInput{
+			FileSystemId: aws.String(fileSystem.id),
+			LustreConfiguration: &fsxtypes.DeleteFileSystemLustreConfiguration{
+				SkipFinalBackup: aws.Bool(true),
+			},
+		}
+		if _, err := svc.DeleteFileSystem(context.TODO(), input); err != nil {
+			logger.Warningf("%s: delete failed: %v", fileSystem.ARN(), err)
+		}
+	}
+
+	return nil
+}
+
+func (FSxLustreFileSystems) ListAll(opts Options) (*Set, error) {
+	svc := fsx.NewFromConfig(*opts.Config, func(opt *fsx.Options) {
+		opt.Region = opts.Region
+	})
+	return listAllFSxLustreFileSystems(svc, opts)
+}
+
+func listAllFSxLustreFileSystems(svc fsxClient, opts Options) (*Set, error) {
+	set := NewSet(0)
+	fileSystems, err := describeFSxFileSystems(svc)
+	if err != nil {
+		return set, errors.Wrapf(err, "couldn't describe FSx file systems for %q in %q", opts.Account, opts.Region)
+	}
+
+	now := time.Now()
+	for _, description := range fileSystems {
+		if description.FileSystemType != fsxtypes.FileSystemTypeLustre {
+			continue
+		}
+		fileSystem, err := newFSxLustreFileSystem(description)
+		if err != nil {
+			return set, err
+		}
+		set.firstSeen[fileSystem.ResourceKey()] = now
+	}
+
+	return set, nil
+}
+
+func describeFSxFileSystems(svc fsxClient) ([]fsxtypes.FileSystem, error) {
+	paginator := fsx.NewDescribeFileSystemsPaginator(svc, &fsx.DescribeFileSystemsInput{})
+	var fileSystems []fsxtypes.FileSystem
+
+	for paginator.HasMorePages() {
+		page, err := paginator.NextPage(context.TODO())
+		if err != nil {
+			return nil, err
+		}
+		fileSystems = append(fileSystems, page.FileSystems...)
+	}
+
+	return fileSystems, nil
+}
+
+func newFSxLustreFileSystem(description fsxtypes.FileSystem) (*fsxLustreFileSystem, error) {
+	if description.FileSystemId == nil || *description.FileSystemId == "" {
+		return nil, errors.New("service returned a Lustre file system without an ID")
+	}
+	if description.ResourceARN == nil || *description.ResourceARN == "" {
+		return nil, fmt.Errorf("file system %q returned by FSx has no ARN", *description.FileSystemId)
+	}
+
+	return &fsxLustreFileSystem{
+		arn: *description.ResourceARN,
+		id:  *description.FileSystemId,
+	}, nil
+}
+
+func fromFSxTags(fsxTags []fsxtypes.Tag) (Tags, error) {
+	tags := make(Tags, len(fsxTags))
+	for i, tag := range fsxTags {
+		if tag.Key == nil || *tag.Key == "" {
+			return nil, fmt.Errorf("tag %d has no key", i)
+		}
+		tags[*tag.Key] = aws.ToString(tag.Value)
+	}
+	return tags, nil
+}
+
+type fsxLustreFileSystem struct {
+	arn string
+	id  string
+}
+
+func (fileSystem fsxLustreFileSystem) ARN() string {
+	return fileSystem.arn
+}
+
+func (fileSystem fsxLustreFileSystem) ResourceKey() string {
+	return fileSystem.ARN()
+}

--- a/aws-janitor/resources/fsx_test.go
+++ b/aws-janitor/resources/fsx_test.go
@@ -1,0 +1,373 @@
+/*
+Copyright 2026 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package resources
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"testing"
+	"time"
+
+	"github.com/aws/aws-sdk-go-v2/aws"
+	"github.com/aws/aws-sdk-go-v2/service/fsx"
+	fsxtypes "github.com/aws/aws-sdk-go-v2/service/fsx/types"
+	"github.com/google/go-cmp/cmp"
+)
+
+type mockFSxPage struct {
+	fileSystems []fsxtypes.FileSystem
+	nextToken   *string
+	err         error
+}
+
+type mockFSxClient struct {
+	pages          map[string]mockFSxPage
+	deleteErrors   map[string]error
+	deleteInputs   []*fsx.DeleteFileSystemInput
+	describeTokens []string
+	events         []string
+}
+
+func (client *mockFSxClient) DescribeFileSystems(_ context.Context, input *fsx.DescribeFileSystemsInput, _ ...func(*fsx.Options)) (*fsx.DescribeFileSystemsOutput, error) {
+	token := aws.ToString(input.NextToken)
+	client.describeTokens = append(client.describeTokens, token)
+	client.events = append(client.events, "describe:"+token)
+
+	page, ok := client.pages[token]
+	if !ok {
+		return nil, fmt.Errorf("unexpected pagination token %q", token)
+	}
+	if page.err != nil {
+		return nil, page.err
+	}
+	return &fsx.DescribeFileSystemsOutput{
+		FileSystems: page.fileSystems,
+		NextToken:   page.nextToken,
+	}, nil
+}
+
+func (client *mockFSxClient) DeleteFileSystem(_ context.Context, input *fsx.DeleteFileSystemInput, _ ...func(*fsx.Options)) (*fsx.DeleteFileSystemOutput, error) {
+	copiedInput := *input
+	if input.LustreConfiguration != nil {
+		copiedConfiguration := *input.LustreConfiguration
+		copiedInput.LustreConfiguration = &copiedConfiguration
+	}
+	client.deleteInputs = append(client.deleteInputs, &copiedInput)
+
+	id := aws.ToString(input.FileSystemId)
+	client.events = append(client.events, "delete:"+id)
+	if err := client.deleteErrors[id]; err != nil {
+		return nil, err
+	}
+	return &fsx.DeleteFileSystemOutput{
+		FileSystemId: input.FileSystemId,
+		Lifecycle:    fsxtypes.FileSystemLifecycleDeleting,
+	}, nil
+}
+
+func TestMarkAndSweepFSxLustreFileSystemsSelectsManagedResources(t *testing.T) {
+	now := time.Now()
+	old := now.Add(-48 * time.Hour)
+	recent := now.Add(-time.Hour)
+	ttlOverrideOld := now.Add(-2 * time.Hour)
+
+	client := &mockFSxClient{
+		pages: map[string]mockFSxPage{
+			"": {
+				fileSystems: []fsxtypes.FileSystem{
+					testFSxFileSystem("fs-old", fsxtypes.FileSystemTypeLustre, fsxtypes.FileSystemLifecycleAvailable, old, map[string]string{"owned": "true"}),
+					testFSxFileSystem("fs-recent", fsxtypes.FileSystemTypeLustre, fsxtypes.FileSystemLifecycleAvailable, recent, map[string]string{"owned": "true"}),
+					testFSxFileSystem("fs-untagged", fsxtypes.FileSystemTypeLustre, fsxtypes.FileSystemLifecycleAvailable, old, nil),
+					testFSxFileSystem("fs-excluded", fsxtypes.FileSystemTypeLustre, fsxtypes.FileSystemLifecycleAvailable, old, map[string]string{"owned": "true", "preserve": "true"}),
+					testFSxFileSystem("fs-windows", fsxtypes.FileSystemTypeWindows, fsxtypes.FileSystemLifecycleAvailable, old, map[string]string{"owned": "true"}),
+					testFSxFileSystem("fs-deleting", fsxtypes.FileSystemTypeLustre, fsxtypes.FileSystemLifecycleDeleting, old, map[string]string{"owned": "true"}),
+					testFSxFileSystem("fs-ttl", fsxtypes.FileSystemTypeLustre, fsxtypes.FileSystemLifecycleAvailable, ttlOverrideOld, map[string]string{"owned": "true", "janitor-ttl": "1h"}),
+				},
+			},
+		},
+	}
+
+	opts := Options{
+		Account:     "123456789012",
+		Region:      "us-west-2",
+		IncludeTags: mustTagMatcher(t, "owned=true"),
+		ExcludeTags: mustTagMatcher(t, "preserve=true"),
+		TTLTagKey:   "janitor-ttl",
+	}
+	if err := markAndSweepFSxLustreFileSystems(client, opts, NewSet(24*time.Hour)); err != nil {
+		t.Fatalf("markAndSweepFSxLustreFileSystems() error = %v", err)
+	}
+
+	if diff := cmp.Diff([]string{"fs-old", "fs-ttl"}, deletedFSxIDs(client)); diff != "" {
+		t.Errorf("deleted file systems mismatch (-want +got):\n%s", diff)
+	}
+	for _, input := range client.deleteInputs {
+		if input.LustreConfiguration == nil || !aws.ToBool(input.LustreConfiguration.SkipFinalBackup) {
+			t.Errorf("DeleteFileSystem(%q) did not explicitly skip the final backup", aws.ToString(input.FileSystemId))
+		}
+		if input.OpenZFSConfiguration != nil || input.WindowsConfiguration != nil {
+			t.Errorf("DeleteFileSystem(%q) included a non-Lustre deletion configuration", aws.ToString(input.FileSystemId))
+		}
+	}
+}
+
+func TestMarkAndSweepFSxLustreFileSystemsDryRun(t *testing.T) {
+	old := time.Now().Add(-48 * time.Hour)
+	client := &mockFSxClient{
+		pages: map[string]mockFSxPage{
+			"": {
+				fileSystems: []fsxtypes.FileSystem{
+					testFSxFileSystem("fs-old", fsxtypes.FileSystemTypeLustre, fsxtypes.FileSystemLifecycleAvailable, old, nil),
+				},
+			},
+		},
+	}
+
+	if err := markAndSweepFSxLustreFileSystems(client, Options{DryRun: true}, NewSet(0)); err != nil {
+		t.Fatalf("markAndSweepFSxLustreFileSystems() error = %v", err)
+	}
+	if len(client.deleteInputs) != 0 {
+		t.Errorf("dry run issued %d DeleteFileSystem calls, want 0", len(client.deleteInputs))
+	}
+}
+
+func TestMarkAndSweepFSxLustreFileSystemsPaginatesBeforeDeleting(t *testing.T) {
+	old := time.Now().Add(-48 * time.Hour)
+	client := &mockFSxClient{
+		pages: map[string]mockFSxPage{
+			"": {
+				fileSystems: []fsxtypes.FileSystem{
+					testFSxFileSystem("fs-first", fsxtypes.FileSystemTypeLustre, fsxtypes.FileSystemLifecycleAvailable, old, nil),
+				},
+				nextToken: aws.String("second"),
+			},
+			"second": {
+				fileSystems: []fsxtypes.FileSystem{
+					testFSxFileSystem("fs-second", fsxtypes.FileSystemTypeLustre, fsxtypes.FileSystemLifecycleAvailable, old, nil),
+				},
+			},
+		},
+	}
+
+	if err := markAndSweepFSxLustreFileSystems(client, Options{}, NewSet(0)); err != nil {
+		t.Fatalf("markAndSweepFSxLustreFileSystems() error = %v", err)
+	}
+	wantEvents := []string{"describe:", "describe:second", "delete:fs-first", "delete:fs-second"}
+	if diff := cmp.Diff(wantEvents, client.events); diff != "" {
+		t.Errorf("API call order mismatch (-want +got):\n%s", diff)
+	}
+}
+
+func TestMarkAndSweepFSxLustreFileSystemsDoesNotDeleteAfterDescribeFailure(t *testing.T) {
+	old := time.Now().Add(-48 * time.Hour)
+	describeErr := errors.New("describe failed")
+	client := &mockFSxClient{
+		pages: map[string]mockFSxPage{
+			"": {
+				fileSystems: []fsxtypes.FileSystem{
+					testFSxFileSystem("fs-first", fsxtypes.FileSystemTypeLustre, fsxtypes.FileSystemLifecycleAvailable, old, nil),
+				},
+				nextToken: aws.String("second"),
+			},
+			"second": {err: describeErr},
+		},
+	}
+
+	err := markAndSweepFSxLustreFileSystems(client, Options{}, NewSet(0))
+	if !errors.Is(err, describeErr) {
+		t.Fatalf("markAndSweepFSxLustreFileSystems() error = %v, want wrapped describe error", err)
+	}
+	if len(client.deleteInputs) != 0 {
+		t.Errorf("issued %d DeleteFileSystem calls after pagination failed, want 0", len(client.deleteInputs))
+	}
+}
+
+func TestMarkAndSweepFSxLustreFileSystemsContinuesAfterDeleteFailure(t *testing.T) {
+	old := time.Now().Add(-48 * time.Hour)
+	client := &mockFSxClient{
+		pages: map[string]mockFSxPage{
+			"": {
+				fileSystems: []fsxtypes.FileSystem{
+					testFSxFileSystem("fs-first", fsxtypes.FileSystemTypeLustre, fsxtypes.FileSystemLifecycleAvailable, old, nil),
+					testFSxFileSystem("fs-second", fsxtypes.FileSystemTypeLustre, fsxtypes.FileSystemLifecycleAvailable, old, nil),
+				},
+			},
+		},
+		deleteErrors: map[string]error{"fs-first": errors.New("delete failed")},
+	}
+
+	if err := markAndSweepFSxLustreFileSystems(client, Options{}, NewSet(0)); err != nil {
+		t.Fatalf("markAndSweepFSxLustreFileSystems() error = %v", err)
+	}
+	if diff := cmp.Diff([]string{"fs-first", "fs-second"}, deletedFSxIDs(client)); diff != "" {
+		t.Errorf("delete attempts mismatch (-want +got):\n%s", diff)
+	}
+}
+
+func TestMarkAndSweepFSxLustreFileSystemsRejectsIncompleteMetadata(t *testing.T) {
+	old := time.Now().Add(-48 * time.Hour)
+	testCases := []struct {
+		name   string
+		mutate func(*fsxtypes.FileSystem)
+	}{
+		{
+			name: "missing ID",
+			mutate: func(fileSystem *fsxtypes.FileSystem) {
+				fileSystem.FileSystemId = nil
+			},
+		},
+		{
+			name: "missing ARN",
+			mutate: func(fileSystem *fsxtypes.FileSystem) {
+				fileSystem.ResourceARN = nil
+			},
+		},
+		{
+			name: "missing tag key",
+			mutate: func(fileSystem *fsxtypes.FileSystem) {
+				fileSystem.Tags = []fsxtypes.Tag{{Value: aws.String("value")}}
+			},
+		},
+	}
+
+	for _, testCase := range testCases {
+		t.Run(testCase.name, func(t *testing.T) {
+			valid := testFSxFileSystem("fs-valid", fsxtypes.FileSystemTypeLustre, fsxtypes.FileSystemLifecycleAvailable, old, nil)
+			invalid := testFSxFileSystem("fs-invalid", fsxtypes.FileSystemTypeLustre, fsxtypes.FileSystemLifecycleAvailable, old, nil)
+			testCase.mutate(&invalid)
+			client := &mockFSxClient{
+				pages: map[string]mockFSxPage{
+					"": {fileSystems: []fsxtypes.FileSystem{valid, invalid}},
+				},
+			}
+
+			if err := markAndSweepFSxLustreFileSystems(client, Options{}, NewSet(0)); err == nil {
+				t.Fatal("markAndSweepFSxLustreFileSystems() error = nil, want metadata validation error")
+			}
+			if len(client.deleteInputs) != 0 {
+				t.Errorf("issued %d DeleteFileSystem calls with incomplete metadata, want 0", len(client.deleteInputs))
+			}
+		})
+	}
+}
+
+func TestListAllFSxLustreFileSystems(t *testing.T) {
+	now := time.Now()
+	client := &mockFSxClient{
+		pages: map[string]mockFSxPage{
+			"": {
+				fileSystems: []fsxtypes.FileSystem{
+					testFSxFileSystem("fs-lustre-a", fsxtypes.FileSystemTypeLustre, fsxtypes.FileSystemLifecycleAvailable, now, nil),
+					testFSxFileSystem("fs-windows", fsxtypes.FileSystemTypeWindows, fsxtypes.FileSystemLifecycleAvailable, now, nil),
+				},
+				nextToken: aws.String("second"),
+			},
+			"second": {
+				fileSystems: []fsxtypes.FileSystem{
+					testFSxFileSystem("fs-lustre-b", fsxtypes.FileSystemTypeLustre, fsxtypes.FileSystemLifecycleCreating, now, nil),
+				},
+			},
+		},
+	}
+
+	set, err := listAllFSxLustreFileSystems(client, Options{Account: "123456789012", Region: "us-west-2"})
+	if err != nil {
+		t.Fatalf("listAllFSxLustreFileSystems() error = %v", err)
+	}
+	wantARNs := []string{
+		testFSxARN("fs-lustre-a"),
+		testFSxARN("fs-lustre-b"),
+	}
+	if diff := cmp.Diff(wantARNs, set.GetARNs()); diff != "" {
+		t.Errorf("listed file systems mismatch (-want +got):\n%s", diff)
+	}
+	if diff := cmp.Diff([]string{"", "second"}, client.describeTokens); diff != "" {
+		t.Errorf("pagination tokens mismatch (-want +got):\n%s", diff)
+	}
+}
+
+func TestListAllFSxLustreFileSystemsReturnsDescribeError(t *testing.T) {
+	describeErr := errors.New("describe failed")
+	client := &mockFSxClient{
+		pages: map[string]mockFSxPage{"": {err: describeErr}},
+	}
+
+	_, err := listAllFSxLustreFileSystems(client, Options{})
+	if !errors.Is(err, describeErr) {
+		t.Fatalf("listAllFSxLustreFileSystems() error = %v, want wrapped describe error", err)
+	}
+}
+
+func TestFSxLustreFileSystemsRegisteredBeforeNetworkResources(t *testing.T) {
+	fsxIndex := -1
+	networkInterfacesIndex := -1
+	for i, resourceType := range RegionalTypeList {
+		switch resourceType.(type) {
+		case FSxLustreFileSystems:
+			fsxIndex = i
+		case NetworkInterfaces:
+			networkInterfacesIndex = i
+		}
+	}
+
+	if fsxIndex == -1 {
+		t.Fatal("FSxLustreFileSystems is not registered in RegionalTypeList")
+	}
+	if networkInterfacesIndex == -1 {
+		t.Fatal("NetworkInterfaces is not registered in RegionalTypeList")
+	}
+	if fsxIndex >= networkInterfacesIndex {
+		t.Errorf("FSxLustreFileSystems index = %d, want before NetworkInterfaces index %d", fsxIndex, networkInterfacesIndex)
+	}
+}
+
+func testFSxFileSystem(id string, fileSystemType fsxtypes.FileSystemType, lifecycle fsxtypes.FileSystemLifecycle, creationTime time.Time, tagValues map[string]string) fsxtypes.FileSystem {
+	tags := make([]fsxtypes.Tag, 0, len(tagValues))
+	for key, value := range tagValues {
+		tags = append(tags, fsxtypes.Tag{Key: aws.String(key), Value: aws.String(value)})
+	}
+	return fsxtypes.FileSystem{
+		CreationTime:   &creationTime,
+		FileSystemId:   aws.String(id),
+		FileSystemType: fileSystemType,
+		Lifecycle:      lifecycle,
+		ResourceARN:    aws.String(testFSxARN(id)),
+		Tags:           tags,
+	}
+}
+
+func testFSxARN(id string) string {
+	return "arn:aws:fsx:us-west-2:123456789012:file-system/" + id
+}
+
+func mustTagMatcher(t *testing.T, tags ...string) TagMatcher {
+	t.Helper()
+	matcher, err := TagMatcherForTags(tags)
+	if err != nil {
+		t.Fatalf("TagMatcherForTags(%v) error = %v", tags, err)
+	}
+	return matcher
+}
+
+func deletedFSxIDs(client *mockFSxClient) []string {
+	ids := make([]string, 0, len(client.deleteInputs))
+	for _, input := range client.deleteInputs {
+		ids = append(ids, aws.ToString(input.FileSystemId))
+	}
+	return ids
+}

--- a/aws-janitor/resources/list.go
+++ b/aws-janitor/resources/list.go
@@ -86,6 +86,7 @@ var RegionalTypeList = []Type{
 	LaunchConfigurations{},
 	LaunchTemplates{},
 	Instances{},
+	FSxLustreFileSystems{},
 	VPCEndpoints{},
 	// Addresses
 	NetworkInterfaces{},

--- a/go.mod
+++ b/go.mod
@@ -20,6 +20,7 @@ require (
 	github.com/aws/aws-sdk-go-v2/service/elasticloadbalancing v1.26.3
 	github.com/aws/aws-sdk-go-v2/service/elasticloadbalancingv2 v1.34.0
 	github.com/aws/aws-sdk-go-v2/service/eventbridge v1.33.3
+	github.com/aws/aws-sdk-go-v2/service/fsx v1.60.2
 	github.com/aws/aws-sdk-go-v2/service/iam v1.34.3
 	github.com/aws/aws-sdk-go-v2/service/route53 v1.42.3
 	github.com/aws/aws-sdk-go-v2/service/s3 v1.58.2

--- a/go.sum
+++ b/go.sum
@@ -150,6 +150,8 @@ github.com/aws/aws-sdk-go-v2/service/elasticloadbalancingv2 v1.34.0 h1:8rDRtPOu3
 github.com/aws/aws-sdk-go-v2/service/elasticloadbalancingv2 v1.34.0/go.mod h1:L5bVuO4PeXuDuMYZfL3IW69E6mz6PDCYpp6IKDlcLMA=
 github.com/aws/aws-sdk-go-v2/service/eventbridge v1.33.3 h1:pjZzcXU25gsD2WmlmlayEsyXIWMVOK3//x4BXvK9c0U=
 github.com/aws/aws-sdk-go-v2/service/eventbridge v1.33.3/go.mod h1:4ew4HelByABYyBE+8iU8Rzrp5PdBic5yd9nFMhbnwE8=
+github.com/aws/aws-sdk-go-v2/service/fsx v1.60.2 h1:0ADY6sOC594lvWksDrmFddKvP84KSL4Y7zvs2pzR3/Q=
+github.com/aws/aws-sdk-go-v2/service/fsx v1.60.2/go.mod h1:dhXtQ2bFU5nBz8muqZ6xibPxkXqpKT09S13q2ke8a70=
 github.com/aws/aws-sdk-go-v2/service/iam v1.34.3 h1:p4L/tixJ3JUIxCteMGT6oMlqCbEv/EzSZoVwdiib8sU=
 github.com/aws/aws-sdk-go-v2/service/iam v1.34.3/go.mod h1:rfOWxxwdecWvSC9C2/8K/foW3Blf+aKnIIPP9kQ2DPE=
 github.com/aws/aws-sdk-go-v2/service/internal/accept-encoding v1.11.3 h1:dT3MqvGhSoaIhRseqw2I0yH81l7wiR2vjs57O51EAm8=


### PR DESCRIPTION
Adds FSx for Lustre to the AWS janitor. Currently, e2e runs in https://github.com/kubernetes-sigs/aws-fsx-csi-drive can leave filesystems behind, and cleanup in the repo only runs when presubmits run.