### PR TITLE
skip stackset IAM roles

### DIFF
--- a/aws-janitor/resources/iam_roles.go
+++ b/aws-janitor/resources/iam_roles.go
@@ -75,6 +75,10 @@ func roleIsManaged(role iamv2types.Role) bool {
 	if strings.HasPrefix(*role.RoleName, "DatadogIntegration") {
 		return false
 	}
+	// Skip StackSets execution roles, which are created by AWS when using CloudFormation StackSets
+	if strings.HasPrefix(*role.RoleName, "stacksets-exec") {
+		return false
+	}
 
 	return !builtinRoles.Has(*role.RoleName)
 }


### PR DESCRIPTION
Boskos is breaking Stackset integration

https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/stacksets-orgs-activate-trusted-access.html